### PR TITLE
Feature: Mark the plugin as wordpress plugin in Composer for easier installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "postnl/postnl-for-woocommerce",
   "license": "GPL-3.0",
+  "type": "wordpress-plugin",
   "require": {
 	"clegginabox/pdf-merger": "dev-master"
   },


### PR DESCRIPTION
Hi,

When trying to install this plugin using Composer, it is not marked as a WordPress plugin, which causes it to get placed in the `vendor` directory instead of the `wp-content/plugins` directory. This PR fixes this.