### PR TITLE
Fix/merge labels in bulk - Use the same barcode if it's created within 7 days.

### DIFF
--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -374,6 +374,11 @@ abstract class Base {
 
 		$saved_data['labels'] = array_merge( $labels, $return_labels );
 		*/
+		$saved_data['barcode'] = array(
+			'value'      => $barcode,
+			'created_at' => current_time( 'timestamp' ),
+		);
+
 		$saved_data['labels'] = $labels;
 		$order->update_meta_data( $this->meta_name, $saved_data );
 		$order->save();
@@ -500,6 +505,17 @@ abstract class Base {
 	 * @throws \Exception Error when response does not have Barcode value.
 	 */
 	public function create_barcode( $order ) {
+		$saved_data = $this->get_data( $order->get_id() );
+
+		// Check if barcode has been created on the last 7 days.
+		if ( ! empty( $saved_data['barcode']['created_at'] ) && ! empty( $saved_data['barcode']['value'] ) ) {
+			$time_deviation = current_time( 'timestamp' ) - intval( $saved_data['barcode']['created_at'] );
+
+			if ( $time_deviation <= 7 * DAY_IN_SECONDS ) {
+				return $saved_data['barcode']['value'];
+			}
+		}
+
 		$data = array(
 			'order' => $order,
 		);

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -476,9 +476,10 @@ abstract class Base {
 					}
 
 					$labels[] = array(
-						'type'     => $label_type,
-						'barcode'  => $barcode,
-						'filepath' => $filepath,
+						'type'       => $label_type,
+						'barcode'    => $barcode,
+						'created_at' => current_time( 'timestamp' ),
+						'filepath'   => $filepath,
 					);
 				}
 			}
@@ -599,9 +600,10 @@ abstract class Base {
 		}
 
 		$merged_labels[ $label_type ] = array(
-			'type'     => $label_type,
-			'barcode'  => $barcode,
-			'filepath' => $merged_info['filepath'],
+			'type'       => $label_type,
+			'barcode'    => $barcode,
+			'created_at' => current_time( 'timestamp' ),
+			'filepath'   => $merged_info['filepath'],
 		);
 
 		return $merged_labels;

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -78,17 +78,6 @@ class Bulk extends Base {
 		if ( ! empty( $object_ids ) ) {
 			foreach ( $object_ids as $order_id ) {
 				try {
-					$saved_data = $this->get_data( $order_id );
-
-					if ( ! empty( $saved_data['labels']['label']['created_at'] ) && ! empty( $saved_data['labels']['label']['filepath'] ) ) {
-						$time_deviation = current_time( 'timestamp' ) - intval( $saved_data['labels']['label']['created_at'] );
-
-						if ( $time_deviation <= 7 * DAY_IN_SECONDS ) {
-							$saved_datas[] = $saved_data;
-							continue;
-						}
-					}
-
 					$saved_datas[] = $this->save_meta_value( $order_id, $_REQUEST );
 					$tracking_note = $this->get_tracking_note( $order_id );
 

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -78,6 +78,17 @@ class Bulk extends Base {
 		if ( ! empty( $object_ids ) ) {
 			foreach ( $object_ids as $order_id ) {
 				try {
+					$saved_data = $this->get_data( $order_id );
+
+					if ( ! empty( $saved_data['labels']['label']['created_at'] ) && ! empty( $saved_data['labels']['label']['filepath'] ) ) {
+						$time_deviation = current_time( 'timestamp' ) - intval( $saved_data['labels']['label']['created_at'] );
+
+						if ( $time_deviation <= 7 * DAY_IN_SECONDS ) {
+							$saved_datas[] = $saved_data;
+							continue;
+						}
+					}
+
 					$saved_datas[] = $this->save_meta_value( $order_id, $_REQUEST );
 					$tracking_note = $this->get_tracking_note( $order_id );
 


### PR DESCRIPTION
### Description

Currently, the plugin will always create a new barcode whenever the label is created. This PR will prevent that. It will check if there is any existing barcode within 7 days and use that instead.

### Steps to Test

1. Create a couple of new order.
2. Create a new shipping label on one of the order.
3. Go to orders list in the admin and check a couple of orders that you just created.
4. Choose "PostNL Create Label" in the bulk action and click "Submit" button.
5. When the label creation is finished, you will notice that the shipping label will still use the same barcode.