### PR TITLE
Fix cart ( non-standard delivery fee ) name and support multiple types

### DIFF
--- a/src/Frontend/Base.php
+++ b/src/Frontend/Base.php
@@ -340,13 +340,10 @@ abstract class Base {
 		$data = $this->get_data( $order->get_id() );
 
 		$add_optional_fee  = true;
-		$non_standard_fees = array(
-			self::evening_fee_data(),
-			self::morning_fee_data()
-		);
+		$non_standard_fees = self::non_standard_fees_data();
 
-		foreach ( $non_standard_fees as $fee ) {
-			if ( $fee['condition']['value'] === $data['frontend'][ $fee['condition']['key'] ] ) {
+		foreach ( $non_standard_fees as $type => $fee ) {
+			if ( $type === $data['frontend'][ $fee['condition']['key'] ] ) {
 				$fee_name  = $fee['fee_name'];
 				$fee_price = $fee['fee_price'];
 				break;

--- a/src/Frontend/Base.php
+++ b/src/Frontend/Base.php
@@ -426,7 +426,7 @@ abstract class Base {
 	}
 
 	/**
-	 * Get evening fee data.
+	 * Get morning fee data.
 	 *
 	 * @return array
 	 */
@@ -441,6 +441,18 @@ abstract class Base {
 				'key'   => 'delivery_day_type',
 				'value' => '08:00-12:00',
 			),
+		);
+	}
+
+	/**
+	 * Get available nonstandard delivery time fees data
+	 *
+	 * @return array
+	 */
+	public static function non_standard_fees_data() {
+		return array(
+			'08:00-12:00' => self::morning_fee_data(),
+			'Evening'     => self::evening_fee_data()
 		);
 	}
 }

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -383,9 +383,11 @@ class Container {
 			return;
 		}
 
-		if ( ! empty( $post_data['postnl_delivery_day_price'] ) && 'delivery_day' === $post_data['postnl_option'] ) {
-			$evening_fee = Base::evening_fee_data();
-			$cart->add_fee( $evening_fee['fee_name'], wc_format_decimal( $post_data['postnl_delivery_day_price'] ) );
+		$non_standard_fees        = Base::non_standard_fees_data();
+		$is_non_standard_delivery = isset( $non_standard_fees[ $post_data['postnl_delivery_day_type'] ] );
+
+		if ( ! empty( $post_data['postnl_delivery_day_price'] ) && 'delivery_day' === $post_data['postnl_option'] && $is_non_standard_delivery ) {
+			$cart->add_fee( $non_standard_fees[ $post_data['postnl_delivery_day_type'] ]['fee_name'], wc_format_decimal( $post_data['postnl_delivery_day_price'] ) );
 		}
 	}
 

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -221,7 +221,7 @@ class Container {
 			return $default_val;
 		}
 
-		$evening_fee = Base::evening_fee_data();
+		$non_standard_fees = Base::non_standard_fees_data();
 
 		foreach ( $response['DeliveryOptions'] as $delivery_option ) {
 			if ( empty( $delivery_option['DeliveryDate'] ) || empty( $delivery_option['Timeframe'] ) ) {
@@ -229,9 +229,9 @@ class Container {
 			}
 
 			$options = array_map(
-				function( $timeframe ) use ( $evening_fee ) {
+				function( $timeframe ) use ( $non_standard_fees ) {
 					$type  = array_shift( $timeframe['Options'] );
-					$price = ( 'Evening' === $type ) ? $evening_fee['fee_price'] : 0;
+					$price = isset( $non_standard_fees[ $type ] ) ? $non_standard_fees[ $type ]['fee_price'] : 0;
 
 					return array(
 						'from'  => Utils::get_hour_min( $timeframe['From'] ),

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -245,8 +245,8 @@ class Container {
 
 			$options = array_filter(
 				$options,
-				function( $option ) {
-					return ( 'Evening' !== $option['type'] && '08:00-12:00' !== $option['type'] );
+				function( $option ) use ( $non_standard_fees ) {
+					return isset( $non_standard_fees[ $option['type'] ] );
 				}
 			);
 

--- a/src/Frontend/Delivery_Day.php
+++ b/src/Frontend/Delivery_Day.php
@@ -117,9 +117,8 @@ class Delivery_Day extends Base {
 			return array();
 		}
 
-		$evening_fee = parent::evening_fee_data();
-		$morning_fee = parent::morning_fee_data();
-		$return_data = $this->get_init_content_data( $post_data );
+		$non_standard_fees = Base::non_standard_fees_data();
+		$return_data       = $this->get_init_content_data( $post_data );
 
 		foreach ( $response['DeliveryOptions'] as $delivery_option ) {
 			if ( empty( $delivery_option['DeliveryDate'] ) || empty( $delivery_option['Timeframe'] ) ) {
@@ -127,20 +126,9 @@ class Delivery_Day extends Base {
 			}
 
 			$options = array_map(
-				function( $timeframe ) use ( $evening_fee, $morning_fee ) {
+				function( $timeframe ) use ( $non_standard_fees ) {
 					$type  = array_shift( $timeframe['Options'] );
-
-					switch ( $type ) {
-						case 'Evening' :
-							$price = $evening_fee['fee_price'];
-							break;
-						case '08:00-12:00' :
-							$price = $morning_fee['fee_price'];
-							break;
-						default :
-							$price = 0;
-							break;
-					}
+					$price = $non_standard_fees[ $type ] ? $non_standard_fees[ $type ]['fee_price'] : 0;
 
 					return array(
 						'from'  => Utils::get_hour_min( $timeframe['From'] ),


### PR DESCRIPTION
### Description

Currently, the plugin will always show "PostNL Evening Fee" as a cart fee even if you select Morning delivery. This PR fix it and will show the correct fee name.

### Steps to Test

1. In checkout, use a valid Netherlands shipping address.
2. Select Delivery Day and choose Morning delivery
3. Check the fee name in the cart totals table.