### PR TITLE
Remove globalpack barcode types validation

### DIFF
--- a/src/Rest_API/Barcode/Item_Info.php
+++ b/src/Rest_API/Barcode/Item_Info.php
@@ -135,15 +135,6 @@ class Item_Info extends Base_Info {
 			'globalpack_barcode_type' => array(
 				'rename'   => 'barcode_type',
 				'default'  => '3S',
-				'validate' => function( $type ) use ( $self ) {
-					$available_type = array_keys( Utils::get_available_barcode_type() );
-					if ( $self->is_rest_of_world() && ! in_array( $type, $available_type, true ) ) {
-						throw new \Exception(
-							// translators: %1$s is a barcode type.
-							sprintf( esc_html__( 'Barcode type: %1$s is not available!', 'postnl-for-woocommerce' ), $type )
-						);
-					}
-				},
 				'sanitize' => function( $value ) use ( $self ) {
 					if ( ! $self->is_rest_of_world() ) {
 						return '3S';

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -236,23 +236,6 @@ class Utils {
 	}
 
 	/**
-	 * Get the available barcode type.
-	 *
-	 * @return String
-	 */
-	public static function get_available_barcode_type() {
-		return array(
-			'3S' => '3S',
-			'2S' => '2S',
-			'CC' => 'CC',
-			'CP' => 'CP',
-			'CD' => 'CD',
-			'CF' => 'CF',
-			'LA' => 'LA',
-		);
-	}
-
-	/**
 	 * Generate the label file name.
 	 *
 	 * @param Int    $order_id ID of the order object.


### PR DESCRIPTION
### Description

 Remove globalpack barcode types validation 

### Steps to Test

1. Change the  (GlobalPack Barcode Type) in the plugin setting : Shipping > manage shipping methods > PostNL, and use any random letters ( To test the wrong barcode scenario ).
2. Create an international order and choose PostNL as a shipping method.
3. As an Admin, try to generate the shipping label for the order, An error message should appear.
4. Change the (GlobalPack Barcode Type) to 'CD' or any other barcode type and retry the previews step.