### PR TITLE
Fix/label creation fatal error

### DIFF
--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -223,7 +223,7 @@ class Item_Info extends Base_Info {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product = $item->get_product();
 
-			if ( empty( $product ) || $product->is_virtual() ) {
+			if ( ! is_a( $product, 'WC_Product' ) || $product->is_virtual() ) {
 				continue;
 			}
 

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -223,7 +223,7 @@ class Item_Info extends Base_Info {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product = $item->get_product();
 
-			if ( $product->is_virtual() ) {
+			if ( empty( $product ) || $product->is_virtual() ) {
 				continue;
 			}
 


### PR DESCRIPTION
### Description
Fix fatal error when trying to create label for order with **deleted product**.

### Steps to Test
1. Create an Order with PostNL as the shipping method.
2. Delete one of the order _WooCommerce products_ and try to create the label.