### PR TITLE
Feature/associated shipping methods

### DIFF
--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -155,13 +155,14 @@ class Container {
 			$available_country = Mapping::available_country_for_checkout_feature();
 			$receiver_country  = ! empty( $post_data['shipping_country'] ) ? $post_data['shipping_country'] : '';
 			$store_country     = Utils::get_base_country();
+			$sipping_methods   = $this->settings->get_supported_shipping_methods();
 
 			if ( ! isset( $available_country[ $store_country ][ $receiver_country ] ) ) {
 				return array();
 			}
 
 			foreach ( $post_data as $post_key => $post_value ) {
-				if ( false !== strpos( $post_key, 'shipping_method' ) && false === strpos( $post_value[0], POSTNL_SETTINGS_ID ) ) {
+				if ( false !== strpos( $post_key, 'shipping_method' ) && ! in_array( Utils::get_cart_shipping_method_id( $post_value[0] ), $sipping_methods ) ) {
 					return array();
 				}
 			}

--- a/src/Main.php
+++ b/src/Main.php
@@ -195,7 +195,7 @@ class Main {
 	 * @return array<WC_Shipping_Method>
 	 */
 	public function add_shipping_method( $shipping_methods ) {
-		$shipping_methods[ $this->settings_id ] = new Shipping_Method\PostNL();
+		$shipping_methods[ $this->settings_id ] = 'PostNLWooCommerce\Shipping_Method\PostNL';
 		return $shipping_methods;
 	}
 

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -317,7 +317,7 @@ abstract class Base {
 		}
 
 		foreach ( $shipping_methods as $shipping_item ) {
-			if ( POSTNL_SETTINGS_ID === $shipping_item->get_method_id() ) {
+			if ( in_array( $shipping_item->get_method_id(), $this->settings->get_supported_shipping_methods() ) ) {
 				return true;
 			}
 		}

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -229,6 +229,14 @@ class Settings extends \WC_Settings_API {
 				'type'        => 'title',
 				'description' => esc_html__( 'Please configure your checkout preferences.', 'postnl-for-woocommerce' ),
 			),
+			'supported_shipping_methods' => array(
+				'title'       => esc_html__( 'Shipping Methods', 'postnl-for-woocommerce' ),
+				'type'        => 'multiselect',
+				'description' => esc_html__( 'Select Shipping Methods can be associated with PostNL.', 'postnl-for-woocommerce' ),
+				'desc_tip'    => true,
+				'options'     => $this->get_shipping_methods(),
+				'class'       => 'wc-enhanced-select',
+			),
 			'enable_pickup_points'      => array(
 				'title'       => __( 'PostNL Pick-up Points', 'postnl-for-woocommerce' ),
 				'type'        => 'checkbox',
@@ -1190,5 +1198,27 @@ class Settings extends \WC_Settings_API {
 	 */
 	public function is_logging_enabled() {
 		return ( 'yes' === $this->get_enable_logging() );
+	}
+
+	/**
+	 * Return array of shipping methods.
+	 *
+	 * @return array.
+	 */
+	public function get_shipping_methods() {
+		return  wp_list_pluck( WC()->shipping->get_shipping_methods(), 'method_title', 'id' );
+	}
+
+	/**
+	 * Get supported shipping methods from the settings.
+	 *
+	 * @return array.
+	 */
+	public function get_supported_shipping_methods() {
+		$suppoted_shipping_methods = (array) $this->get_option( 'supported_shipping_methods' );
+		// Add PostNL method by default
+		$suppoted_shipping_methods[] = POSTNL_SETTINGS_ID;
+
+		return $suppoted_shipping_methods;
 	}
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -480,4 +480,19 @@ class Utils {
 
 		return isset( $papers[ $paper ] ) ? $papers[ $paper ] : array();
 	}
+
+	/**
+	 * @param string $shipping_method Cart shipping method.
+	 *
+	 * @return string.
+	 */
+	public static function get_cart_shipping_method_id( $shipping_method ) {
+		if( empty( $shipping_method ) ) {
+			return $shipping_method;
+		}
+
+		// Assumes format 'name:id'
+		$shipping_method = explode(':', $shipping_method );
+		return $shipping_method[0] ?? $shipping_method;
+	}
 }


### PR DESCRIPTION
### Description
Add an field to select which Shipping Methods can be associated with PostNL and default to PostNL.

### Steps to Test
1. Edit plugin settings from WooCommerce > Settings > Shipping > PostNL, Under "Checkout Settings" you will find "Shipping Methods" fill it with associated methods and save the settings.
2. After adding products to the cart, and selecting any associated method as a shipping method for the cart, PostNL fields should be displayed.
3. Also PostNL metabox should be displayed in the admin dashboard order edit screen.