### PR TITLE
Fix/multicollo barcode - Fixing Multicollo Barcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Requires at least: 4.6
 * Requires PHP: 5.6
 * Tested up to: 6.2
-* Stable tag: 5.2.4
+* Stable tag: 5.2.5
 * WC requires at least: 4.0
 * WC tested up to: 7.8
 * License: GPLv2 or later
@@ -35,6 +35,13 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 
 ## Changelog
+
+### 5.2.5
+* Fix multi-collo barcodes call.
+
+### 5.2.4
+* Fix bug in Bulk actions menu.
+* Add weight limit for Mailbox.
 
 ### 5.2.3
 * Create column for Delivery Date on the order overview page.

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: With this plug-in you can easily confirm your PostNL shipments and print shipping labels in no time. In addition, your customers are more in control because they choose where and when they receive their order.
  * Author: PostNL
  * Author URI: https://postnl.post/
- * Version: 5.2.4
+ * Version: 5.2.5
  * Tested up to: 6.2
  * WC requires at least: 4.0
  * WC tested up to: 7.9

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Version: 5.2.4
  * Tested up to: 6.2
  * WC requires at least: 4.0
- * WC tested up to: 7.8
+ * WC tested up to: 7.9
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.2.5 (2023-xx-xx) =
+* Fix multi-collo barcodes call.
+
 = 5.2.4 (2023-07-25) =
 * Fix bug in Bulk actions menu.
 * Add weight limit for Mailbox.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, export, delivery, packages, PostNL, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.2
-Stable tag: 5.2.4
+Stable tag: 5.2.5
 WC requires at least: 4.0
 WC tested up to: 7.8
 License: GPLv2 or later
@@ -80,7 +80,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
-= 5.2.5 (2023-xx-xx) =
+= 5.2.5 (2023-07-31) =
 * Fix multi-collo barcodes call.
 
 = 5.2.4 (2023-07-25) =

--- a/src/Main.php
+++ b/src/Main.php
@@ -22,7 +22,7 @@ class Main {
 	 *
 	 * @var _version
 	 */
-	private $version = '5.2.4';
+	private $version = '5.2.5';
 
 	/**
 	 * The ID of this plugin settings.

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -547,6 +547,7 @@ abstract class Base {
 		$this->delete_label( $saved_data );
 		unset( $saved_data['backend'] );
 		unset( $saved_data['labels'] );
+		unset( $saved_data['barcodes'] );
 
 		$order->update_meta_data( $this->meta_name, $saved_data );
 		$order->save();

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -427,9 +427,9 @@ abstract class Base {
 			'saved_data' => $saved_data,
 		);
 
-		$barcodes                    = $this->maybe_create_multi_barcodes( $label_post_data );
-		$label_post_data['barcode']  = $barcodes[0]; // for MainBarcode.
-		$label_post_data['barcodes'] = $barcodes;
+		$barcodes                        = $this->maybe_create_multi_barcodes( $label_post_data );
+		$label_post_data['main_barcode'] = $barcodes[0]; // for MainBarcode.
+		$label_post_data['barcodes']     = $barcodes;
 
 		$label_post_data['return_barcode'] = $this->maybe_create_return_barcode( $label_post_data );
 
@@ -808,7 +808,7 @@ abstract class Base {
 		// Check any errors.
 		$this->check_label_and_barcode( $response );
 
-		$labels = $this->put_label_content( $response, $order, $post_data['barcode'], 'label' );
+		$labels = $this->put_label_content( $response, $order, $post_data['main_barcode'], 'label' );
 
 		if ( empty( $labels ) ) {
 			throw new \Exception(
@@ -839,7 +839,7 @@ abstract class Base {
 		$return_label = new Return_Label\Client( $item_info );
 		$response     = $return_label->send_request();
 
-		$labels = $this->put_label_content( $response, $order, $post_data['barcode'], 'return-label' );
+		$labels = $this->put_label_content( $response, $order, $post_data['main_barcode'], 'return-label' );
 
 		if ( empty( $labels ) ) {
 			throw new \Exception(
@@ -870,7 +870,7 @@ abstract class Base {
 		$return_label = new Letterbox\Client( $item_info );
 		$response     = $return_label->send_request();
 
-		$labels = $this->put_label_content( $response, $order, $post_data['barcode'], 'letterbox' );
+		$labels = $this->put_label_content( $response, $order, $post_data['main_barcode'], 'letterbox' );
 
 		if ( empty( $labels ) ) {
 			throw new \Exception(

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -427,8 +427,9 @@ abstract class Base {
 			'saved_data' => $saved_data,
 		);
 
-		$barcode                    = $this->create_barcode( $label_post_data );
-		$label_post_data['barcode'] = $barcode;
+		$barcodes                    = $this->maybe_create_multi_barcodes( $label_post_data );
+		$label_post_data['barcode']  = $barcodes[0]; // for MainBarcode.
+		$label_post_data['barcodes'] = $barcodes;
 
 		$label_post_data['return_barcode'] = $this->maybe_create_return_barcode( $label_post_data );
 
@@ -442,9 +443,15 @@ abstract class Base {
 
 		$saved_data['labels'] = array_merge( $labels, $return_labels );
 		*/
-		$saved_data['barcode'] = array(
-			'value'      => $barcode,
-			'created_at' => current_time( 'timestamp' ),
+
+		$saved_data['barcodes'] = array_map(
+			function( $barc ) {
+				return array(
+					'value'      => $barc,
+					'created_at' => current_time( 'timestamp' ),
+				);
+			},
+			$barcodes
 		);
 
 		$saved_data['labels'] = array_map(
@@ -540,7 +547,6 @@ abstract class Base {
 		$this->delete_label( $saved_data );
 		unset( $saved_data['backend'] );
 		unset( $saved_data['labels'] );
-		unset( $saved_data['barcode'] );
 
 		$order->update_meta_data( $this->meta_name, $saved_data );
 		$order->save();
@@ -614,20 +620,9 @@ abstract class Base {
 	 * @throws \Exception Error when response does not have Barcode value.
 	 */
 	public function create_barcode( $label_post_data ) {
-		$saved_data = $label_post_data['saved_data'];
-
-		// Check if barcode has been created on the last 7 days.
-		if ( ! empty( $saved_data['barcode']['created_at'] ) && ! empty( $saved_data['barcode']['value'] ) ) {
-			$time_deviation = current_time( 'timestamp' ) - intval( $saved_data['barcode']['created_at'] );
-
-			if ( $time_deviation <= 7 * DAY_IN_SECONDS ) {
-				return $saved_data['barcode']['value'];
-			}
-		}
-
 		$data = array(
 			'order'      => $label_post_data['order'],
-			'saved_data' => $saved_data
+			'saved_data' => $label_post_data['saved_data'],
 		);
 
 		$item_info = new Barcode\Item_Info( $data );
@@ -641,6 +636,42 @@ abstract class Base {
 		}
 
 		return $response['Barcode'];
+	}
+
+	/**
+	 * Get multi barcodes from cacne or create new barcodes for current order.
+	 *
+	 * @param array $post_data Order post data.
+	 *
+	 * @return array
+	 *
+	 * @throws \Exception Error when response has an error.
+	 */
+	public function maybe_create_multi_barcodes( $post_data ) {
+		// Minimum number of labels is 1 so it will create at least 1 barcode.
+		$num_labels = 1;
+		$barcodes   = array();
+		$saved_data = $post_data['saved_data'];
+
+		if ( isset( $saved_data['backend']['num_labels'] ) && 1 < intval( $saved_data['backend']['num_labels'] ) ) {
+			$num_labels = intval( $saved_data['backend']['num_labels'] );
+		}
+
+		for ( $i = 0; $i < $num_labels; $i++ ) {
+			// Check if barcode has been created on the last 7 days before creating a new one.
+			if ( ! empty( $saved_data['barcodes'][ $i ]['created_at'] ) && ! empty( $saved_data['barcodes'][ $i ]['value'] ) ) {
+				$time_deviation = current_time( 'timestamp' ) - intval( $saved_data['barcodes'][ $i ]['created_at'] );
+
+				if ( $time_deviation <= 7 * DAY_IN_SECONDS ) {
+					$barcodes[ $i ] = $saved_data['barcodes'][ $i ]['value'];
+					continue;
+				}
+			}
+
+			$barcodes[ $i ] = $this->create_barcode( $post_data );
+		}
+
+		return $barcodes;
 	}
 
 	/**

--- a/src/Rest_API/Shipping/Client.php
+++ b/src/Rest_API/Shipping/Client.php
@@ -88,7 +88,7 @@ class Client extends Base {
 
 		$shipment = array(
 			'Addresses'           => $this->get_shipment_addresses(),
-			'Barcode'             => $this->item_info->shipment['barcode'],
+			'Barcode'             => $this->item_info->shipment['main_barcode'],
 			'Contacts'            => array(
 				array(
 					'ContactType' => '01',
@@ -143,13 +143,13 @@ class Client extends Base {
 
 		for ( $i = 1; $i <= $this->item_info->backend_data['num_labels']; $i++ ) {
 			if ( $this->item_info->backend_data['num_labels'] > 1 ) {
-				unset( $shipment['Barcode'] );
-				$shipment['Groups'] = array(
+				$shipment['Barcode'] = $this->item_info->shipment['barcodes'][ ( $i - 1 ) ];
+				$shipment['Groups']  = array(
 					array(
 						'GroupType'     => '03',
 						'GroupCount'    => $this->item_info->backend_data['num_labels'],
 						'GroupSequence' => $i,
-						'MainBarcode'   => $this->item_info->shipment['barcode'],
+						'MainBarcode'   => $this->item_info->shipment['main_barcode'],
 					),
 				);
 			}

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -221,7 +221,8 @@ class Item_Info extends Base_Info {
 		$this->api_args['order_details'] = array(
 			'order_id'       => $order->get_id(),
 			'order_number'   => $order->get_order_number(),
-			'barcode'        => $post_data['barcode'],
+			'main_barcode'   => $post_data['barcode'],
+			'barcodes'       => $post_data['barcodes'],
 			'return_barcode' => $post_data['return_barcode'],
 			'currency'       => $order->get_currency(),
 			'total_weight'   => $order_weight,
@@ -394,19 +395,22 @@ class Item_Info extends Base_Info {
 		$self = $this;
 
 		return array(
-			'order_id'        => array(
+			'order_id'         => array(
 				'error' => __( 'Order ID is empty!', 'postnl-for-woocommerce' ),
 			),
-			'order_number'        => array(
+			'order_number'     => array(
 				'error' => __( 'Order number is empty!', 'postnl-for-woocommerce' ),
 			),
-			'barcode'         => array(
+			'main_barcode'     => array(
 				'error' => __( 'Barcode is empty!', 'postnl-for-woocommerce' ),
 			),
-			'return_barcode'  => array(
+			'barcodes'         => array(
+				'default' => array(),
+			),
+			'return_barcode'   => array(
 				'default' => '',
 			),
-			'shipping_product'    => array(
+			'shipping_product' => array(
 				'error'    => __( 'Product code is empty!', 'postnl-for-woocommerce' ),
 				'validate' => function( $value ) {
 					if ( empty( $value ) || ! is_numeric( $value['code'] ) && 4 !== strlen( $value['code'] ) ) {

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -221,7 +221,7 @@ class Item_Info extends Base_Info {
 		$this->api_args['order_details'] = array(
 			'order_id'       => $order->get_id(),
 			'order_number'   => $order->get_order_number(),
-			'main_barcode'   => $post_data['barcode'],
+			'main_barcode'   => $post_data['main_barcode'],
 			'barcodes'       => $post_data['barcodes'],
 			'return_barcode' => $post_data['return_barcode'],
 			'currency'       => $order->get_currency(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR will create unique barcode for each labels if the user input number of labels more than 1.
This PR also change some variable in the create label ( `/v1/shipment` ) request.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a new order.
2. Create a PostNL label from Order edit page in admin.
3. Print the label. Each label will have unique barcode.
4. Check the log from WooCommerce >> Status >> Log. The request will show `Barcode` for each addresses array. And `MainBarcode` will always use the first barcode.
Example : 
<img width="1296" alt="Screenshot 2023-07-26 at 14 41 21" src="https://github.com/Progressus-io/postnl-for-woocommerce/assets/631098/6af5c199-1d36-40d0-91cd-654d6e02afa7">


<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fix multi-collo barcodes call.