### PR TITLE
Hpos order list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Tested up to: 6.3
 * Stable tag: 5.3.2
 * WC requires at least: 4.0
-* WC tested up to: 8.2
+* WC tested up to: 8.4
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,11 +37,12 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 ## Changelog
 
 ### 5.3.2
-* Add: Made the delivery date sortable by date.
-* Added Dutch translations in the PostNL settings screen in WooCommerce shipping settings.
+* Fix: Bulk action does not work in HPOS.
 
 ### 5.3.1
 * Fix: Change store address error text.
+* Add: Made the delivery date sortable by date.
+* Added Dutch translations in the PostNL settings screen in WooCommerce shipping settings.
 
 ### 5.3.0
 * Add: New product codes for shipping from Belgium to Netherlands.

--- a/assets/js/admin-order-bulk.js
+++ b/assets/js/admin-order-bulk.js
@@ -3,7 +3,7 @@
 	var postnl_order_bulk = {
 		// init Class
 		init: function() {
-			var posts_filter = jQuery( '#posts-filter' );
+			var posts_filter = jQuery( '#posts-filter, #wc-orders-filter' );
 			
 			posts_filter
 				.on( 'change', '#bulk-action-selector-top', this.toggle_create_label_modal );
@@ -18,7 +18,7 @@
 
 			var value 		= jQuery( this ).val();
 			var title 		= jQuery(':selected', this ).text();
-			var post_form 	= jQuery( this ).parents('#posts-filter');
+			var post_form 	= jQuery( this ).parents('#posts-filter, #wc-orders-filter');
 
 			if( 'postnl-create-label' == value ){
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 5.3.1
 WC requires at least: 4.0
-WC tested up to: 8.2
+WC tested up to: 8.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -79,6 +79,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 5. PostNL information on the order details page
 
 == Changelog ==
+
+= 5.3.2 (2023-xx-xx) =
+* Fix: Bulk action does not work in HPOS.
 
 = 5.3.1 (2023-11-21) =
 * Fix: Change store address error text.

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -33,10 +33,10 @@ class Bulk extends Base {
 	public function init_hooks() {
 		add_filter( 'bulk_actions-edit-shop_order', array( $this, 'add_order_bulk_actions' ), 10, 1 );
 		add_filter( 'handle_bulk_actions-edit-shop_order', array( $this, 'process_order_bulk_actions' ), 10, 3 );
-		
+
 		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'add_order_bulk_actions' ), 10, 1 );
 		add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $this, 'process_order_bulk_actions' ), 10, 3 );
-		
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_bulk_assets' ) );
 		add_action( 'admin_footer', array( $this, 'model_content_fields_create_label' ) );
 		add_filter( 'postnl_order_meta_box_fields', array( $this, 'additional_meta_box' ), 10, 1 );
@@ -223,7 +223,9 @@ class Bulk extends Base {
 	public function enqueue_bulk_assets() {
 		$screen = get_current_screen();
 
-		if ( ! empty( $screen->id ) && 'edit-shop_order' === $screen->id && ! empty( $screen->base ) && 'edit' === $screen->base ) {
+		$is_legacy_order = ! empty( $screen->id ) && 'edit-shop_order' === $screen->id && ! empty( $screen->base ) && 'edit' === $screen->base;
+		$is_hpos_order   = ! empty( $screen->id ) && 'woocommerce_page_wc-orders' === $screen->id && ( empty( $_GET['action'] ) || 'edit' !== $_GET['action'] );
+		if ( $is_legacy_order || $is_hpos_order ) {
 			// Enqueue the assets.
 			wp_enqueue_style( 'thickbox' );
 			wp_enqueue_script( 'thickbox' );
@@ -282,14 +284,19 @@ class Bulk extends Base {
 	 * Collection of fields in create label bulk action.
 	 */
 	public function model_content_fields_create_label() {
-		global $pagenow, $typenow, $thepostid, $post;
+		global $thepostid, $post;
+
+		$screen = get_current_screen();
+
+		$is_legacy_order = ! empty( $screen->id ) && 'edit-shop_order' === $screen->id && ! empty( $screen->base ) && 'edit' === $screen->base;
+		$is_hpos_order   = ! empty( $screen->id ) && 'woocommerce_page_wc-orders' === $screen->id && ( empty( $_GET['action'] ) || 'edit' !== $_GET['action'] );
 
 		// Bugfix, warnings shown for Order table results with no Orders.
-		if ( empty( $thepostid ) && empty( $post ) ) {
+		if ( $is_legacy_order && empty( $thepostid ) && empty( $post ) ) {
 			return;
 		}
 
-		if ( 'shop_order' === $typenow && 'edit.php' === $pagenow ) {
+		if ( $is_legacy_order || $is_hpos_order ) {
 			?>
 			<div id="postnl-create-label-modal" style="display:none;">
 				<div id="postnl-action-create-label">
@@ -309,7 +316,10 @@ class Bulk extends Base {
 	public function render_messages() {
 		$current_screen = get_current_screen();
 
-		if ( isset( $current_screen->id ) && in_array( $current_screen->id, array( 'shop_order', 'edit-shop_order' ), true ) ) {
+		$is_legacy_order = isset( $current_screen->id ) && in_array( $current_screen->id, array( 'shop_order', 'edit-shop_order' ), true );
+		$is_hpos_order   = ! empty( $current_screen->id ) && 'woocommerce_page_wc-orders' === $current_screen->id;
+
+		if ( $is_legacy_order || $is_hpos_order ) {
 
 			$bulk_action_message_opt = get_option( $this->bulk_option_text_name );
 

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -33,6 +33,10 @@ class Bulk extends Base {
 	public function init_hooks() {
 		add_filter( 'bulk_actions-edit-shop_order', array( $this, 'add_order_bulk_actions' ), 10, 1 );
 		add_filter( 'handle_bulk_actions-edit-shop_order', array( $this, 'process_order_bulk_actions' ), 10, 3 );
+		
+		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'add_order_bulk_actions' ), 10, 1 );
+		add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $this, 'process_order_bulk_actions' ), 10, 3 );
+		
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_bulk_assets' ) );
 		add_action( 'admin_footer', array( $this, 'model_content_fields_create_label' ) );
 		add_filter( 'postnl_order_meta_box_fields', array( $this, 'additional_meta_box' ), 10, 1 );

--- a/src/Order/OrdersList.php
+++ b/src/Order/OrdersList.php
@@ -26,21 +26,27 @@ class OrdersList extends Base {
 	public function init_hooks() {
 		// add 'Delivery Date' orders page column header
 		add_filter( 'manage_edit-shop_order_columns', array( $this, 'add_order_delivery_date_column_header' ), 29 );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_order_delivery_date_column_header' ), 29 );
 
 		// add 'Delivery Date' orders page column content
 		add_action( 'manage_shop_order_posts_custom_column', array( $this, 'add_order_delivery_date_column_content' ), 10, 2 );
+		add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'add_order_delivery_date_column_content' ), 10, 2 );
 
 		// add 'Shipping options' orders page column header
 		add_filter( 'manage_edit-shop_order_columns', array( $this, 'add_order_shipping_options_column_header' ), 30 );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_order_shipping_options_column_header' ), 30 );
 
 		// add 'Shipping options' orders page column content
 		add_action( 'manage_shop_order_posts_custom_column', array( $this, 'add_order_shipping_options_column_content' ), 10, 2 );
+		add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'add_order_shipping_options_column_content' ), 10, 2 );
 
 		// add 'Label Created' orders page column header
 		add_filter( 'manage_edit-shop_order_columns', array( $this, 'add_order_barcode_column_header' ), 31 );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_order_barcode_column_header' ), 31 );
 
 		// add 'Label Created' orders page column content
 		add_action( 'manage_shop_order_posts_custom_column', array( $this, 'add_order_barcode_column_content' ), 10, 2 );
+		add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'add_order_barcode_column_content' ), 10, 2 );
 
 		// Make delivery date column sortable.
 		add_filter( 'manage_edit-shop_order_sortable_columns', array( $this, 'sort_delivery_date_column' ) );


### PR DESCRIPTION
Make the plugin fully compatible with HPOS.

### Steps to test : 
1. Activate the plugin.
2. Activate the HPOS from WooCommerce >> Settings >> Feature.
3. Try to create an order.
4. Try to use bulk action to create a label.
5. The process will be the same as in legacy order.