### PR TITLE
check if product is exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.4.2
 * Fix: Error "Invalid nonce" when trying to delete labels.
+* Fix: Orders list fetal error if order have deleted product.
 
 ### 5.4.1
 * Fix: Display shipping options within the order list for legacy orders storage.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.4.2 (2024-xx-xx) =
 * Fix: Error "Invalid nonce" when trying to delete labels.
+* Fix: Orders list fetal error if order have deleted product.
 
 = 5.4.1 (2024-06-11) =
 * Fix: Display shipping options within the order list for legacy orders storage.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -735,6 +735,11 @@ class Utils {
 
 		foreach ( $products as $item_id => $item ) {
 			$product              = wc_get_product( $item['product_id'] ?? $item->get_product_id() );
+			if ( ! $product ) {
+				// If the product is not found, consider the order not eligible.
+				return false;
+			}
+
 			$is_letterbox_product = $product->get_meta( Product\Single::LETTERBOX_PARCEL );
 
 			// If one of the item is not letterbox product, then the order is not eligible automatic letterbox.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -735,7 +735,7 @@ class Utils {
 
 		foreach ( $products as $item_id => $item ) {
 			$product              = wc_get_product( $item['product_id'] ?? $item->get_product_id() );
-			if ( ! $product ) {
+			if ( ! is_a( $product, 'WC_Product' ) ) {
 				// If the product is not found, consider the order not eligible.
 				return false;
 			}


### PR DESCRIPTION
https://app.clickup.com/t/8688wz6gw
Fatal error: Uncaught Error: Call to a member function get_meta() on bool in /home/customer/www/[eluun.nl/public_html/wp-content/plugins/woo-postnl/src/Utils.php:738](http://eluun.nl/public_html/wp-content/plugins/woo-postnl/src/Utils.php:738)

this error indicates that the $product is false, meaning that wc_get_product is unable to find a product for a given item ID. This can happen if the product ID doesn't exist 