### PR TITLE
Product editor compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 * Tags: PostNL, Shipping
 * Requires at least: 4.6
 * Requires PHP: 5.6
-* Tested up to: 6.5
+* Tested up to: 6.6
 * Stable tag: 5.4.2
 * WC requires at least: 4.0
-* WC tested up to: 9.0
+* WC tested up to: 9.1
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,8 +38,6 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.5.0
 * Add: Compatibility with the new WooCommerce Product Editor.
-
-### 5.4.3
 * Fix: HPOS declaration path.
 
 ### 5.4.2

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.5.0
+* Add: Compatibility with the new WooCommerce Product Editor.
+
 ### 5.4.2
 * Fix: Error "Invalid nonce" when trying to delete labels.
 * Fix: Orders list fatal error if order have deleted product.

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -6,9 +6,9 @@
  * Author: PostNL
  * Author URI: https://postnl.post/
  * Version: 5.4.2
- * Tested up to: 6.5
+ * Tested up to: 6.6
  * WC requires at least: 4.0
- * WC tested up to: 9.0
+ * WC tested up to: 9.1
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.5.0 (2024-xx-xx) =
+* Add: Compatibility with the new WooCommerce Product Editor.
+
 = 5.4.2 (2024-07-03) =
 * Fix: Error "Invalid nonce" when trying to delete labels.
 * Fix: Orders list fatal error if order have deleted product.

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: PostNL, shadim, abdalsalaam
 Tags: woocommerce, export, delivery, packages, PostNL, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: 5.4.2
 WC requires at least: 4.0
-WC tested up to: 9.0
+WC tested up to: 9.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -82,8 +82,6 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.5.0 (2024-xx-xx) =
 * Add: Compatibility with the new WooCommerce Product Editor.
-
-= 5.4.3 (2023-xx-xx) =
 * Fix: HPOS declaration path.
 
 = 5.4.2 (2024-07-03) =

--- a/src/Main.php
+++ b/src/Main.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use PostNLWooCommerce\Product\Product_Editor;
+
 /**
  * Class Main
  *
@@ -44,6 +46,13 @@ class Main {
 	 * @var PostNLWooCommerce\Product\PostNL
 	 */
 	public $shipping_product = null;
+
+	/**
+	 * Product Editor.
+	 *
+	 * @var PostNLWooCommerce\Product\Product_Editor
+	 */
+	public $product_editor = null;
 
 	/**
 	 * Shipping Order.
@@ -86,6 +95,7 @@ class Main {
 	public function __construct() {
 		add_action( 'init', array( $this, 'load_plugin' ), 1 );
 		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_hpos_compatibility' ), 10 );
+		add_action( 'before_woocommerce_init', array( $this, 'declare_product_editor_compatibility' ), 10 );
 	}
 
 	/**
@@ -94,6 +104,15 @@ class Main {
 	public function declare_wc_hpos_compatibility() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'postnl-for-woocommerce/postnl-for-woocommerce.php', true );
+		}
+	}
+
+	/**
+	 * Declare Product Editor compatibility.
+	 */
+	public function declare_product_editor_compatibility() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'product_block_editor', 'postnl-for-woocommerce/postnl-for-woocommerce.php', true );
 		}
 	}
 
@@ -162,6 +181,7 @@ class Main {
 		$this->get_orders_list();
 		$this->get_shipping_product();
 		$this->get_frontend();
+		$this->get_product_editor();
 	}
 
 	/**
@@ -249,6 +269,19 @@ class Main {
 		}
 
 		return $this->shipping_product;
+	}
+
+	/**
+	 * Get product editor class.
+	 *
+	 * @return Product\Product_Editor
+	 */
+	public function get_product_editor() {
+		if ( empty( $this->product_editor ) ) {
+			$this->product_editor = new Product\Product_Editor();
+		}
+
+		return $this->product_editor;
 	}
 
 	/**

--- a/src/Main.php
+++ b/src/Main.php
@@ -48,13 +48,6 @@ class Main {
 	public $shipping_product = null;
 
 	/**
-	 * Product Editor.
-	 *
-	 * @var PostNLWooCommerce\Product\Product_Editor
-	 */
-	public $product_editor = null;
-
-	/**
 	 * Shipping Order.
 	 *
 	 * @var PostNLWooCommerce\Order\Single
@@ -81,6 +74,7 @@ class Main {
 	 * @var PostNLWooCommerce\Shipping_Method\Settings
 	 */
 	public $shipping_settings = null;
+	
 
 	/**
 	 * Instance to call certain functions globally within the plugin
@@ -88,6 +82,13 @@ class Main {
 	 * @var _instance
 	 */
 	protected static $instance = null;
+
+	/**
+	 * Product Editor.
+	 *
+	 * @var PostNLWooCommerce\Product\Product_Editor
+	 */
+	public $product_editor = null;
 
 	/**
 	 * Construct the plugin.
@@ -233,6 +234,19 @@ class Main {
 	}
 
 	/**
+	 * Get product editor class.
+	 *
+	 * @return Product\Product_Editor
+	 */
+	public function get_product_editor() {
+		if ( empty( $this->product_editor ) ) {
+			$this->product_editor = new Product\Product_Editor();
+		}
+
+		return $this->product_editor;
+	}
+
+	/**
 	 * Get order bulk class.
 	 *
 	 * @return Order\Bulk
@@ -269,19 +283,6 @@ class Main {
 		}
 
 		return $this->shipping_product;
-	}
-
-	/**
-	 * Get product editor class.
-	 *
-	 * @return Product\Product_Editor
-	 */
-	public function get_product_editor() {
-		if ( empty( $this->product_editor ) ) {
-			$this->product_editor = new Product\Product_Editor();
-		}
-
-		return $this->product_editor;
 	}
 
 	/**

--- a/src/Product/Product_Editor.php
+++ b/src/Product/Product_Editor.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Product editor handler class.
+ *
+ * @package PostNLWooCommerce\Product
+ */
+
+namespace PostNLWooCommerce\Product;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+
+/**
+ * Product editor handler.
+ */
+class Product_Editor {
+
+    /**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_block_template_area_product-form_after_add_block_product-shipping-dimensions', array( $this, 'add_shipping_blocks' ) );
+		add_action( 'woocommerce_block_template_area_product-form_after_add_block_product-variation-shipping-dimensions', array( $this, 'add_shipping_blocks' ) );
+	}
+
+	/**
+	 * Add custom blocks to the product editor shipping section.
+	 *
+	 * @param BlockInterface $shipping_dimensions_block The shipping dimensions block.
+	 */
+	public function add_shipping_blocks( BlockInterface $shipping_dimensions_block ) {
+		if ( ! method_exists( $shipping_dimensions_block, 'get_parent' ) ) {
+			return;
+		}
+
+		$parent = $shipping_dimensions_block->get_parent();
+
+		// Add Letterbox Parcel Checkbox Block.
+		$parent->add_block(
+			array(
+				'id'         => 'postnl-letterbox-parcel',
+				'blockName'  => 'woocommerce/product-checkbox-field',
+				'attributes' => array(
+					'title'          => __( 'PostNL extra settings', 'postnl-for-woocommerce' ),
+					'label'          => __( 'Enable Letterbox Parcel', 'postnl-for-woocommerce' ),
+					'property'       => 'meta_data.' . Single::LETTERBOX_PARCEL,
+					'tooltip'        => __( 'When enabled, PostNL plugin automatically determines whether a shipment fits through a letterbox.', 'postnl-for-woocommerce' ),
+					'checkedValue'   => 'yes',
+					'uncheckedValue' => '',
+				),
+			)
+		);
+
+		// Add Maximum Quantity per Letterbox Number Block.
+		$parent->add_block(
+			array(
+				'id'         => 'postnl-max-qty-per-letterbox',
+				'blockName'  => 'woocommerce/product-number-field',
+				'attributes' => array(
+					'label'       => __( 'Maximum Quantity per Letterbox Parcel', 'postnl-for-woocommerce' ),
+					'property'    => 'meta_data.' . Single::MAX_QTY_PER_LETTERBOX,
+					'placeholder' => __( 'Enter max quantity', 'postnl-for-woocommerce' ),
+					'min'         => 1,
+					'tooltip'     => __( 'Specify how many times this product fits in a letterbox parcel.', 'postnl-for-woocommerce' ),
+				),
+			)
+		);
+
+		// Add Country of Origin Select Block.
+		$parent->add_block(
+			array(
+				'id'         => 'postnl-country-origin',
+				'blockName'  => 'woocommerce/product-select-field',
+				'attributes' => array(
+					'label'    => __( 'Country of Origin', 'postnl-for-woocommerce' ),
+					'property' => 'meta_data.' . Single::ORIGIN_FIELD,
+					'options'  => array_merge(
+						array( array( 'value' => '0', 'label' => __( '- select country -', 'postnl-for-woocommerce' ) ) ),
+						array_map( function( $key, $value ) {
+							return array(
+								'value' => $key,
+								'label' => $value,
+							);
+						}, array_keys( WC()->countries->get_countries() ), WC()->countries->get_countries() )
+					),
+					'tooltip'  => __( 'Select the country of origin for this product.', 'postnl-for-woocommerce' ),
+				),
+			)
+		);
+
+		// Add HS Tariff Code Text Block.
+		$parent->add_block(
+			array(
+				'id'         => 'postnl-hs-code',
+				'blockName'  => 'woocommerce/product-text-field',
+				'attributes' => array(
+					'label'       => __( 'HS Tariff Code', 'postnl-for-woocommerce' ),
+					'property'    => 'meta_data.' . Single::HS_CODE_FIELD,
+					'placeholder' => __( 'HS Code', 'postnl-for-woocommerce' ),
+					'tooltip'     => __( 'HS Tariff Code for international shipping.', 'postnl-for-woocommerce' ),
+				),
+			)
+		);
+	}
+}


### PR DESCRIPTION
**Enhancement: Add Custom Shipping Blocks to the WooCommerce Product Editor**
This PR adds a new Product_Editor class to the PostNL WooCommerce plugin, enhancing the product editor with custom shipping-related blocks. The blocks include:

**Letterbox Parcel Checkbox:** Enable/disable letterbox parcel.
**Max Quantity per Letterbox:** Specify max quantity per letterbox parcel.
**Country of Origin Select:** Choose the country of origin.
**HS Tariff Code Text:** Input HS Tariff Code for international shipping.
The **Product_Editor** class is instantiated in the **Main** class for seamless integration.

![image](https://github.com/user-attachments/assets/07288b8b-2a77-4f61-88c0-a0761e02dffe)

![image](https://github.com/user-attachments/assets/6a8d36b3-97ab-4118-9f72-d723f67bee56)
