### PR TITLE
New: shipment addresses filter hook

### DIFF
--- a/src/Rest_API/Shipping/Client.php
+++ b/src/Rest_API/Shipping/Client.php
@@ -264,6 +264,6 @@ class Client extends Base {
 			);
 		}
 
-		return $addresses;
+		return apply_filters( 'postnl_shipment_addresses', $addresses, $this );
 	}
 }


### PR DESCRIPTION
This pull request introduces a new filter `postnl_shipment_addresses` to modify shipment addresses before generating PostNL shipping labels. The filter is necessary to handle specific address formats used in our plugin, which appends the house number directly to the `address_1` field. Without this filter, the shipping label would display the house number twice—once in `address_1` and once in the `HouseNr` field.

### Usage:

```php
add_filter( 'postnl_shipment_addresses', function( $addresses, $client ) {
	if ( ! empty( $addresses[0]['HouseNr'] ) ) {
		$addresses[0]['HouseNr'] = '';
	}
	
	return $addresses;
}, 10, 2 );
```

### Benefits:

* Ensures correct address formatting for our plugin, preventing duplicated house numbers on PostNL shipping labels.
* Provides a flexible solution that could benefit other scenarios with different address formatting requirements.