### PR TITLE
not to remove the merged file path from the saved data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.6.3
+* Fix: Enabled performing the same bulk action for generating combined PDF labels multiple times.
+
 ### 5.6.2
 * Fix: Ensured that when the return option is set to "None," no return labels are generated for orders.
 

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.6.3 (2025-xx-xx) =
+* Fix: Enabled performing the same bulk action for generating combined PDF labels multiple times.
+
 = 5.6.2 (2024-09-24) =
 * Fix: Ensured that when the return option is set to "None," no return labels are generated for orders.
 

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -537,14 +537,7 @@ abstract class Base {
 			$barcodes
 		);
 
-		$saved_data['labels'] = array_map(
-			function ( $label ) {
-				unset( $label['merged_files'] );
-
-				return $label;
-			},
-			$labels
-		);
+		$saved_data['labels'] = $labels;
 
 		if ( $this->settings->is_auto_complete_order_enabled() ) {
 			// Updating the order status to completed.
@@ -711,7 +704,8 @@ abstract class Base {
 					$label_extension = ! empty( $label_contents['OutputType'] ) ? sanitize_title( $label_contents['OutputType'] ) : 'pdf';
 					$barcode         = $response[ $type ][ $shipment_idx ][ $content_type['barcode_key'] ];
 					$barcode         = is_array( $barcode ) ? array_shift( $barcode ) : $barcode;
-					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, 'A6', $label_extension );
+					$label_format  	 = $this->settings->get_label_format();
+					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, $label_format, $label_extension );
 					$filepath        = trailingslashit( POSTNL_UPLOADS_DIR ) . $filename;
 
 					if ( wp_mkdir_p( POSTNL_UPLOADS_DIR ) && ! file_exists( $filepath ) ) {

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -1271,6 +1271,12 @@ abstract class Base {
 			return false;
 		}
 
+		if( isset( $saved_data['labels']['label']['merged_files'] ) ){
+			foreach ( $saved_data['labels']['label']['merged_files'] as  $label_path ) {
+				unlink( $label_path );
+			}
+		}
+		
 		return unlink( $saved_data['labels']['label']['filepath'] );
 	}
 
@@ -1411,29 +1417,6 @@ abstract class Base {
 		$tracking_url = Utils::generate_tracking_url( $saved_data['labels']['label']['barcode'], $order->get_shipping_country(), $order->get_shipping_postcode() );
 
 		return sprintf( '<a href="%1$s" target="_blank" class="postnl-tracking-link">%2$s</a>', esc_url( $tracking_url ), $saved_data['labels']['label']['barcode'] );
-	}
-
-	/**
-	 * Delete label files from label info.
-	 *
-	 * @param Array $labels List of label info.
-	 */
-	public function delete_label_files( $labels ) {
-		if ( empty( $labels ) ) {
-			return;
-		}
-
-		foreach ( $labels as $label_type => $label_info ) {
-			if ( empty( $label_info['merged_files'] ) || empty( $label_info['filepath'] ) ) {
-				continue;
-			}
-
-			foreach ( $label_info['merged_files'] as $path ) {
-				if ( file_exists( $path ) && $path !== $label_info['filepath'] ) {
-					unlink( $path );
-				}
-			}
-		}
 	}
 
 	/**

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -1271,8 +1271,8 @@ abstract class Base {
 			return false;
 		}
 
-		if( isset( $saved_data['labels']['label']['merged_files'] ) ){
-			foreach ( $saved_data['labels']['label']['merged_files'] as  $label_path ) {
+		if ( isset( $saved_data['labels']['label']['merged_files'] ) ) {
+			foreach ( $saved_data['labels']['label']['merged_files'] as $label_path ) {
 				unlink( $label_path );
 			}
 		}

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -229,10 +229,6 @@ class Bulk extends Base {
 
 		$merged_info = $this->merge_labels( $label_paths, $filename, $start_position );
 
-		foreach ( $gen_labels as $labels ) {
-			$this->delete_label_files( $labels );
-		}
-
 		if ( file_exists( $merged_info ['filepath'] ) ) {
 			// We're saving the bulk file path temporarily and access it later during the download process.
 			// This information expires in 3 minutes (180 seconds), just enough for the user to see the

--- a/src/Order/Single.php
+++ b/src/Order/Single.php
@@ -460,8 +460,6 @@ class Single extends Base {
 			$labels        = $result['labels'];
 			$tracking_note = $this->get_tracking_note( $order_id );
 
-			$this->delete_label_files( $labels );
-
 			if ( ! empty( $tracking_note ) ) {
 				$return_data = array_merge(
 					$result['saved_data'],


### PR DESCRIPTION
This PR contain fix for[ this issue ](https://app.clickup.com/t/868apk1qn)
1. Remove the code that unset merged_files from saved_data array
2. Remove the code that delete the files after merge