### PR TITLE
remove postal code length sanitization from the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.6.3
 * Fix: Enabled performing the same bulk action for generating combined PDF labels multiple times.
+* Fix: Removed 6-character limit for Shipping Postcode to support longer postcodes like in Portugal and Brazil.
 
 ### 5.6.2
 * Fix: Ensured that when the return option is set to "None," no return labels are generated for orders.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.6.3 (2025-xx-xx) =
 * Fix: Enabled performing the same bulk action for generating combined PDF labels multiple times.
+* Fix: Removed 6-character limit for Shipping Postcode to support longer postcodes like in Portugal and Brazil.
 
 = 5.6.2 (2024-09-24) =
 * Fix: Ensured that when the return option is set to "None," no return labels are generated for orders.

--- a/src/Rest_API/Base_Info.php
+++ b/src/Rest_API/Base_Info.php
@@ -179,7 +179,7 @@ abstract class Base_Info {
 			'postcode'     => array(
 				'error'    => __( 'Shipping "Postcode" is empty!', 'postnl-for-woocommerce' ),
 				'sanitize' => function ( $value ) use ( $self ) {
-					return $value = str_replace( ' ', '', $value );
+					return str_replace( ' ', '', $value );
 				},
 			),
 			'state'        => array(

--- a/src/Rest_API/Base_Info.php
+++ b/src/Rest_API/Base_Info.php
@@ -179,9 +179,7 @@ abstract class Base_Info {
 			'postcode'     => array(
 				'error'    => __( 'Shipping "Postcode" is empty!', 'postnl-for-woocommerce' ),
 				'sanitize' => function ( $value ) use ( $self ) {
-					$value = str_replace( ' ', '', $value );
-
-					return $self->string_length_sanitization( $value, 7 );
+					return $value = str_replace( ' ', '', $value );
 				},
 			),
 			'state'        => array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

The fix is related to this [support ticket](https://app.clickup.com/t/8688gpavn)

### How to test the changes in this Pull Request:

1. Create an order with Portugal shipping address
2. Create label for this order
3. Check the postal code in the label if it full or only the first 6 digits

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
