### PR TITLE
Pre release test

### DIFF
--- a/assets/js/admin-order-bulk.js
+++ b/assets/js/admin-order-bulk.js
@@ -66,6 +66,7 @@
                     post_form.find('#postnl-field-container').append('<input type="hidden" name="postnl_default_shipping_options_be" value="' + tb_window.find('#postnl_default_shipping_options_be').val() + '">');
                     post_form.find('#postnl-field-container').append('<input type="hidden" name="postnl_default_shipping_options_eu" value="' + tb_window.find('#postnl_default_shipping_options_eu').val() + '">');
                     post_form.find('#postnl-field-container').append('<input type="hidden" name="postnl_default_shipping_options_row" value="' + tb_window.find('#postnl_default_shipping_options_row').val() + '">');
+					post_form.find('#postnl-field-container').append('<input type="hidden" name="postnl_default_shipping_options_pickup" value="' + tb_window.find('#postnl_default_shipping_options_pickup').val() + '">');
 					jQuery( this ).prop( 'disabled', true );
 					post_form.submit();
 				} );

--- a/assets/js/admin-order-single.js
+++ b/assets/js/admin-order-single.js
@@ -242,5 +242,21 @@
 	
 	postnl_order_single.init();
 
+	if ( $( 'div.pickup-points-info' ).length ) {
+		$( '#postnl_id_check, #postnl_insured_shipping' ).on( 'change', function() {
+			// Get the ID of the current checkbox
+			var currentId = $(this).attr( 'id' );
+			
+			// Uncheck the other checkbox
+			if ( $(this).is( ':checked' ) ) {
+				if ( currentId === 'postnl_id_check' ) {
+					$( '#postnl_insured_shipping' ).prop( 'checked', false );
+				} else {
+					$( '#postnl_id_check' ).prop( 'checked', false );
+				}
+			}
+		});
+	}
+
 	window.postnl_order_single_refresh = postnl_order_single.refresh_items;
 } )( jQuery );

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -5,8 +5,11 @@
  * Description: With this plug-in you can easily confirm your PostNL shipments and print shipping labels in no time. In addition, your customers are more in control because they choose where and when they receive their order.
  * Author: PostNL
  * Author URI: https://postnl.post/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Version: 5.6.2
- * Tested up to: 6.6
+ * Tested up to: 6.7
+ * Requires Plugins: woocommerce
  * WC requires at least: 4.0
  * WC tested up to: 9.3
  *

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PostNL, shadim, abdalsalaam
 Tags: woocommerce, export, delivery, packages, PostNL, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 5.6.2
 WC requires at least: 4.0
 WC tested up to: 9.3

--- a/src/Emails/WC_Email_Smart_Return.php
+++ b/src/Emails/WC_Email_Smart_Return.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'WC_Email_Smart_Return' ) ) :
 		 * @since  3.1.0
 		 */
 		public function get_default_subject() {
-			return __( '[{site_title}]: PostNL Smart Returns', 'woocommerce' );
+			return __( '[{site_title}]: PostNL Smart Returns', 'postnl-for-woocommerce' );
 		}
 
 		/**
@@ -63,7 +63,7 @@ if ( ! class_exists( 'WC_Email_Smart_Return' ) ) :
 		 * @since  3.1.0
 		 */
 		public function get_default_heading() {
-			return __( 'PostNL Smart Returns', 'woocommerce' );
+			return __( 'PostNL Smart Returns', 'postnl-for-woocommerce' );
 		}
 
 		/**

--- a/src/Frontend/Base.php
+++ b/src/Frontend/Base.php
@@ -240,7 +240,7 @@ abstract class Base {
 		$nonce_value    = wc_get_var( $_REQUEST['woocommerce-process-checkout-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // phpcs:ignore
 		$expiry_message = sprintf(
 			/* translators: %s: shop cart url */
-			__( 'Sorry, your session has expired. <a href="%s" class="wc-backward">Return to shop</a>', 'woocommerce' ),
+			__( 'Sorry, your session has expired. <a href="%s" class="wc-backward">Return to shop</a>', 'postnl-for-woocommerce' ),
 			esc_url( wc_get_page_permalink( 'shop' ) )
 		);
 

--- a/src/Helper/Mapping.php
+++ b/src/Helper/Mapping.php
@@ -135,6 +135,16 @@ class Mapping {
 								),
 							),
 						),
+						array(
+							'combination' => array( 'id_check', 'insured_shipping' ),
+							'code'        => '3443',
+							'options'     => array(
+								array(
+									'characteristic' => '002',
+									'option'         => '014',
+								),
+							),
+						),
 					),
 					'pickup_points' => array(
 						array(
@@ -146,6 +156,16 @@ class Mapping {
 							'combination' => array( 'insured_shipping' ),
 							'code'        => '3534',
 							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'id_check' ),
+							'code'        => '3571',
+							'options'     => array(
+								array(
+									'characteristic' => '002',
+									'option'         => '014',
+								),
+							),
 						),
 					)
 				),
@@ -639,6 +659,8 @@ class Mapping {
 							'3089',
 							'3533',
 							'3534',
+							'3443',
+							'3571',
 						),
 						'options'  => array(
 							array(
@@ -662,6 +684,8 @@ class Mapping {
 							'3089',
 							'3533',
 							'3534',
+							'3443',
+							'3571',
 						),
 						'options'  => array(
 							array(

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -543,14 +543,7 @@ abstract class Base {
 			$barcodes
 		);
 
-		$saved_data['labels'] = array_map(
-			function ( $label ) {
-				unset( $label['merged_files'] );
-
-				return $label;
-			},
-			$labels
-		);
+		$saved_data['labels'] = $labels;
 
 		if ( $this->settings->is_auto_complete_order_enabled() ) {
 			// Updating the order status to completed.
@@ -717,7 +710,8 @@ abstract class Base {
 					$label_extension = ! empty( $label_contents['OutputType'] ) ? sanitize_title( $label_contents['OutputType'] ) : 'pdf';
 					$barcode         = $response[ $type ][ $shipment_idx ][ $content_type['barcode_key'] ];
 					$barcode         = is_array( $barcode ) ? array_shift( $barcode ) : $barcode;
-					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, 'A6', $label_extension );
+					$label_format  	 = $this->settings->get_label_format();
+					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, $label_format, $label_extension );
 					$filepath        = trailingslashit( POSTNL_UPLOADS_DIR ) . $filename;
 
 					if ( wp_mkdir_p( POSTNL_UPLOADS_DIR ) && ! file_exists( $filepath ) ) {
@@ -1283,6 +1277,12 @@ abstract class Base {
 			return false;
 		}
 
+		if ( isset( $saved_data['labels']['label']['merged_files'] ) ) {
+			foreach ( $saved_data['labels']['label']['merged_files'] as $label_path ) {
+				unlink( $label_path );
+			}
+		}
+		
 		return unlink( $saved_data['labels']['label']['filepath'] );
 	}
 
@@ -1423,29 +1423,6 @@ abstract class Base {
 		$tracking_url = Utils::generate_tracking_url( $saved_data['labels']['label']['barcode'], $order->get_shipping_country(), $order->get_shipping_postcode() );
 
 		return sprintf( '<a href="%1$s" target="_blank" class="postnl-tracking-link">%2$s</a>', esc_url( $tracking_url ), $saved_data['labels']['label']['barcode'] );
-	}
-
-	/**
-	 * Delete label files from label info.
-	 *
-	 * @param Array $labels List of label info.
-	 */
-	public function delete_label_files( $labels ) {
-		if ( empty( $labels ) ) {
-			return;
-		}
-
-		foreach ( $labels as $label_type => $label_info ) {
-			if ( empty( $label_info['merged_files'] ) || empty( $label_info['filepath'] ) ) {
-				continue;
-			}
-
-			foreach ( $label_info['merged_files'] as $path ) {
-				if ( file_exists( $path ) && $path !== $label_info['filepath'] ) {
-					unlink( $path );
-				}
-			}
-		}
 	}
 
 	/**

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -122,6 +122,12 @@ abstract class Base {
 
 		// Get from the plugin settings
 		$delivery_zone = $this->get_shipping_zone( $order );
+		$frontend_data = $this->get_frontend_data( $order->get_id() );
+
+		if ( ! empty( $frontend_data['dropoff_points'] ) ) {
+			$delivery_zone = 'PICKUP';
+		}
+
 		if ( 'NL' === $delivery_zone && Utils::is_eligible_auto_letterbox( $order ) ) {
 			return array( 'letterbox' => 'yes' );
 		}

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -234,10 +234,6 @@ class Bulk extends Base {
 
 		$merged_info = $this->merge_labels( $label_paths, $filename, $start_position );
 
-		foreach ( $gen_labels as $labels ) {
-			$this->delete_label_files( $labels );
-		}
-
 		if ( file_exists( $merged_info ['filepath'] ) ) {
 			// We're saving the bulk file path temporarily and access it later during the download process.
 			// This information expires in 3 minutes (180 seconds), just enough for the user to see the

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -148,7 +148,7 @@ class Bulk extends Base {
 			$match_pickup_zone 	  = 'PICKUP' === $zone && 'NL' === $this->get_shipping_zone( $order );
 			if ( $have_label_file ) {
 				$array_messages[] = array(
-					'message' => sprintf( esc_html__( 'Order #%1$d already has a label.', 'postnl-for-woocommerce' ), $order_id ),
+					// Translators: %1$d is the order ID.'message' => sprintf( esc_html__( 'Order #%1$d already has a label.', 'postnl-for-woocommerce' ), $order_id ),
 					'type'    => 'error',
 				);
 
@@ -157,7 +157,7 @@ class Bulk extends Base {
 
 			if ( ! $match_shipping_zones && ! $match_pickup_zone ) {
 				$array_messages[] = array(
-					'message' => sprintf( esc_html__( 'Order #%1$d is from another shipping zone.', 'postnl-for-woocommerce' ), $order_id ),
+					// Translators: %1$d is the order ID.'message' => sprintf( esc_html__( 'Order #%1$d is from another shipping zone.', 'postnl-for-woocommerce' ), $order_id ),
 					'type'    => 'error',
 				);
 
@@ -681,6 +681,7 @@ class Bulk extends Base {
 			$order->add_order_note( $tracking_note, $customer_note );
 			$label_link        = esc_url( $this->get_download_label_url( $order_id ) );
 			$result['message'] = array(
+				// Translators: %1$s is the order ID, %2$s is the link to download the file, %3$s is the closing link tag.
 				'message' => sprintf( esc_html__( '#%1$s : PostNL label has been created - %2$sdownload file%3$s', 'postnl-for-woocommerce' ),
 					$order_id, '<a href="' . $label_link . '" download>', '</a>' ),
 				'type'    => 'success',

--- a/src/Order/Single.php
+++ b/src/Order/Single.php
@@ -627,7 +627,10 @@ class Single extends Base {
 
 				wp_send_json_success();
 			} else {
-				throw new \Exception( esc_html__( print_r( $response['errorsPerBarcode'][0]['errors'][0], true ) ) );
+				$error_message = isset($response['errorsPerBarcode'][0]['errors'][0]) ? $response['errorsPerBarcode'][0]['errors'][0] : 'Unknown error';
+
+				// Translators: %s is the error message.
+				throw new \Exception( sprintf( esc_html__( 'Error: %s', 'postnl-for-woocommerce' ), esc_html( $error_message ) ) );
 			}
 		} catch ( \Exception $e ) {
 			wp_send_json_error(

--- a/src/Order/Single.php
+++ b/src/Order/Single.php
@@ -460,8 +460,6 @@ class Single extends Base {
 			$labels        = $result['labels'];
 			$tracking_note = $this->get_tracking_note( $order_id );
 
-			$this->delete_label_files( $labels );
-
 			if ( ! empty( $tracking_note ) ) {
 				$return_data = array_merge(
 					$result['saved_data'],

--- a/src/Rest_API/Base_Info.php
+++ b/src/Rest_API/Base_Info.php
@@ -179,9 +179,7 @@ abstract class Base_Info {
 			'postcode'     => array(
 				'error'    => __( 'Shipping "Postcode" is empty!', 'postnl-for-woocommerce' ),
 				'sanitize' => function ( $value ) use ( $self ) {
-					$value = str_replace( ' ', '', $value );
-
-					return $self->string_length_sanitization( $value, 7 );
+					return $value = str_replace( ' ', '', $value );
 				},
 			),
 			'state'        => array(

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -993,7 +993,8 @@ class Item_Info extends Base_Info {
 		} // For EU shipments, validate that insurance does not exceed €5000
 		elseif ( ! $is_non_eu_shipment && 'yes' === $backend_data['insured_shipping'] && $order_total > 5000 ) {
 			throw new \Exception(
-				__( 'Insurance amount for EU shipments cannot exceed €5000. Your total is: ' . $order_total, 'postnl-for-woocommerce' )
+				// Translators: %s is the order total.
+				sprintf( esc_html__( 'Insurance amount for EU shipments cannot exceed €5000. Your total is: %d', 'postnl-for-woocommerce' ), $order_total )
 			);
 		}
 	}

--- a/src/Shipping_Method/PostNL.php
+++ b/src/Shipping_Method/PostNL.php
@@ -91,6 +91,7 @@ class PostNL extends \WC_Shipping_Flat_Rate {
 		$currency_symbol = get_woocommerce_currency_symbol();
 
 		$form_fields['minimum_for_free_shipping'] = array(
+			// Translators: %s is the currency symbol.
 			'title'    => sprintf( esc_html__( 'Free shipping from %s', 'postnl-for-woocommerce' ), $currency_symbol ),
 			'type'     => 'number',
 			'desc_tip' => esc_html__( 'Keep empty if you don’t want to use Free shipping', 'postnl-for-woocommerce' ),

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -541,6 +541,7 @@ class Settings extends \WC_Settings_API {
 				'options'     => array(
 					'standard_shipment'                                        => __( 'Standard shipment', 'postnl-for-woocommerce' ),
 					'id_check'                                                 => __( 'ID Check', 'postnl-for-woocommerce' ),
+					'id_check|insured_shipping'                                => __( 'ID Check + Insured Shipping', 'postnl-for-woocommerce' ),
 					// 'insured_shipping'                                         => __( 'Insured Shipping', 'postnl-for-woocommerce' ),
 					'return_no_answer'                                         => __( 'Return if no answer', 'postnl-for-woocommerce' ),
 					'signature_on_delivery'                                    => __( 'Signature on Delivery', 'postnl-for-woocommerce' ),
@@ -604,6 +605,17 @@ class Settings extends \WC_Settings_API {
 					'packets'                                        => __( 'Packets', 'postnl-for-woocommerce' ),
 					'packets|track_and_trace'                        => __( 'Packets + Track & Trace', 'postnl-for-woocommerce' ),
 					'packets|track_and_trace|insured_shipping'       => __( 'Packets + Track & Trace + Insured', 'postnl-for-woocommerce' ),
+				),
+			),
+			'default_shipping_options_pickup'   => array(
+				'title'       => __( 'Default Shipping Pickup', 'postnl-for-woocommerce' ),
+				'type'        => 'select',
+				'description' => __( 'Shipping options Pickup.', 'postnl-for-woocommerce' ),
+				'default'     => 'id_check',
+				'for_country' => array( 'NL' ),
+				'options'     => array(
+					'id_check'         => __( 'ID Check', 'postnl-for-woocommerce' ),
+					'insured_shipping' => __( 'Insured Shipping', 'postnl-for-woocommerce' ),
 				),
 			),
 			'auto_complete_order'            => array(

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -692,8 +692,9 @@ class Utils {
 			$products = $order->get_cart();
 		}
 
-		$is_eligible = self::check_products_for_letterbox( $products );
-
+		if( isset( $products ) ) {
+			$is_eligible = self::check_products_for_letterbox( $products );
+		}
 		// Save the state for the order.
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$order->update_meta_data( '_postnl_letterbox', $is_eligible );

--- a/templates/checkout/postnl-delivery-day.php
+++ b/templates/checkout/postnl-delivery-day.php
@@ -53,7 +53,7 @@ if ( empty( $data['delivery_options'] ) ) {
 									name="<?php echo esc_attr( $data['field_name'] ); ?>" 
 									class="postnl_sub_radio" 
 									value="<?php echo esc_attr( $value ); ?>"
-									<?php echo $is_checked; ?>
+									<?php echo wp_kses_post( $is_checked ); ?>
 								/>
 								<i><?php echo wp_kses_post( $is_charged ); ?></i>
 								<i><?php echo esc_html( $delivery_time ); ?></i>


### PR DESCRIPTION
### All Submissions:



<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
https://github.com/Progressus-io/postnl-for-woocommerce/pull/193
https://app.clickup.com/t/8689buv73
https://app.clickup.com/t/8685026vy


https://github.com/Progressus-io/postnl-for-woocommerce/pull/194
https://app.clickup.com/t/868afmcmk


https://github.com/Progressus-io/postnl-for-woocommerce/pull/195
https://app.clickup.com/t/868apk1qn

https://github.com/Progressus-io/postnl-for-woocommerce/pull/198
https://app.clickup.com/t/8688gpavn

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->





<!-- Mark completed items with an [x] -->

### Changelog entry

Add:
Introduced the "ID Check" shipping option for pick-up points, enabling merchants to offer pick-up point delivery for products requiring age verification. This option is available in both the Label & Tracking menu and bulk actions.
Added "Pick-up at PostNL" as a shipping zone in the default shipping options and included it in the bulk actions menu with related shipping options.
Implemented the "ID Check + Insured Shipping" product option for domestic orders. Merchants can now select both "ID Check" and "Insured Shipping" in the Label & Tracking menu.

Update:
Ensured compatibility with WordPress 6.7 by updating the plugin to address new features and potential issues.

Fix:
Removed the character limit on postal codes to support longer postcodes used in countries like Portugal and Brazil, ensuring complete addresses are sent in the API call and printed on labels.
Resolved an issue where reprinting combined labels via bulk action was not possible after the first attempt. Merged files are now retained, allowing multiple downloads of combined PDF labels.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
