### PR TITLE
change shipping zone for TF and GC states to be ROW instead of EU

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 ### 5.6.5
 * Fix: Improved error messages for Shipping & Return label activation.
 * Fix: Postcode and city fields were incorrectly applied to both Freepost and home addresses in Smart Return shipments.
+* Fix: Adjusted shipping classification for the Canary Islands to use the correct product code and country code.
 
 ### 5.6.4
 * Fix: Add Standard Shipping to Default Shipping Pickup options.

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 = 5.6.5 (2025-xx-xx) =
 * Fix: Improved error messages for Shipping & Return label activation.
 * Fix: Postcode and city fields were incorrectly applied to both Freepost and home addresses in Smart Return shipments.
+* Fix: Adjusted shipping classification for the Canary Islands to use the correct product code and country code.
 
 = 5.6.4 (2025-02-04) =
 * Fix: Add Standard Shipping to Default Shipping Pickup options.

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -121,7 +121,7 @@ abstract class Base {
 		}
 
 		// Get from the plugin settings
-		$delivery_zone = $this->get_shipping_zone( $order );
+		$delivery_zone = Utils::get_shipping_zone( $order->get_shipping_country(), $order->get_shipping_state() );
 		$frontend_data = $this->get_frontend_data( $order->get_id() );
 
 		if ( ! empty( $frontend_data['dropoff_points'] ) ) {
@@ -133,32 +133,6 @@ abstract class Base {
 		}
 
 		return $this->settings->get_default_shipping_options( $delivery_zone );
-	}
-
-	/**
-	 * Get delivery zone out of the given order ( 1 of 4 - nl, be, eu, row )
-	 *
-	 * @param \WC_Order $order
-	 *
-	 * @return string
-	 */
-	public function get_shipping_zone( $order ) {
-		$shipping_destination = $order->get_shipping_country();
-		$shipping_state       = $order->get_shipping_state();
-
-		if ( in_array( $shipping_destination, array( 'NL', 'BE' ) ) ) {
-			return $shipping_destination;
-		}
-
-		if ( in_array( $shipping_state, array( 'TF', 'GC' ) ) ) {
-			return 'ROW';
-		}
-
-		if ( in_array( $shipping_destination, WC()->countries->get_european_union_countries() ) ) {
-			return 'EU';
-		}
-
-		return 'ROW';
 	}
 
 	/**

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -144,7 +144,7 @@ abstract class Base {
 	 */
 	public function get_shipping_zone( $order ) {
 		$shipping_destination = $order->get_shipping_country();
-		$shipping_state 	  = $order->get_shipping_state();
+		$shipping_state       = $order->get_shipping_state();
 
 		if ( in_array( $shipping_destination, array( 'NL', 'BE' ) ) ) {
 			return $shipping_destination;

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -144,9 +144,14 @@ abstract class Base {
 	 */
 	public function get_shipping_zone( $order ) {
 		$shipping_destination = $order->get_shipping_country();
+		$shipping_state 	  = $order->get_shipping_state();
 
 		if ( in_array( $shipping_destination, array( 'NL', 'BE' ) ) ) {
 			return $shipping_destination;
+		}
+
+		if ( in_array( $shipping_state, array( 'TF', 'GC' ) ) ) {
+			return 'ROW';
 		}
 
 		if ( in_array( $shipping_destination, WC()->countries->get_european_union_countries() ) ) {
@@ -377,7 +382,7 @@ abstract class Base {
 
 		$product_map  = Mapping::products_data();
 		$from_country = Utils::get_base_country();
-		$to_country   = Utils::get_shipping_zone( $order->get_shipping_country() );
+		$to_country   = Utils::get_shipping_zone( $order->get_shipping_country(), $order->get_shipping_state() );
 		$saved_data   = $this->get_data( $order->get_id() );
 
 		if ( empty( $saved_data['frontend'] ) ) {
@@ -626,9 +631,10 @@ abstract class Base {
 	public function get_delivery_type( $order ) {
 		$from_country      = Utils::get_base_country();
 		$to_country        = $order->get_shipping_country();
+		$to_state          = $order->get_shipping_state();
 		$delivery_type_map = Mapping::delivery_type();
 		$filtered_frontend = $this->get_order_frontend_info( $order, '_type' );
-		$destination       = Utils::get_shipping_zone( $to_country );
+		$destination       = Utils::get_shipping_zone( $to_country, $to_state );
 
 
 		if ( ! is_array( $delivery_type_map[ $from_country ][ $destination ] ) ) {
@@ -914,7 +920,8 @@ abstract class Base {
 
 		$from_country    = Utils::get_base_country();
 		$to_country      = $order->get_shipping_country();
-		$destination     = Utils::get_shipping_zone( $to_country );
+		$to_state        = $order->get_shipping_state();
+		$destination     = Utils::get_shipping_zone( $to_country, $to_state );
 		$label_type_list = Mapping::label_type_list();
 
 		$available_type = ( ! empty( $label_type_list[ $from_country ][ $destination ] ) ) ? $label_type_list[ $from_country ][ $destination ] : array( 'label' );

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -121,18 +121,18 @@ abstract class Base {
 		}
 
 		// Get from the plugin settings
-		$delivery_zone = Utils::get_shipping_zone( $order->get_shipping_country(), $order->get_shipping_state() );
+		$shipping_zone = Utils::get_shipping_zone( $order->get_shipping_country(), $order->get_shipping_state() );
 		$frontend_data = $this->get_frontend_data( $order->get_id() );
 
 		if ( ! empty( $frontend_data['dropoff_points'] ) ) {
-			$delivery_zone = 'PICKUP';
+			$shipping_zone = 'PICKUP';
 		}
 
-		if ( 'NL' === $delivery_zone && Utils::is_order_eligible_auto_letterbox( $order ) ) {
+		if ( 'NL' === $shipping_zone && Utils::is_order_eligible_auto_letterbox( $order ) ) {
 			return array( 'letterbox' => 'yes' );
 		}
 
-		return $this->settings->get_default_shipping_options( $delivery_zone );
+		return $this->settings->get_default_shipping_options( $shipping_zone );
 	}
 
 	/**

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -140,15 +140,17 @@ class Bulk extends Base {
 
 		$selected_shipping_options = $this->prepare_default_options( $_REQUEST );
 		$zone                      = strtoupper( sanitize_text_field( $_REQUEST['postnl_shipping_zone'] ) );
-    
-    foreach ( $object_ids as $order_id ) {
+
+		foreach ( $object_ids as $order_id ) {
 			$order                = wc_get_order( $order_id );
 			$have_label_file      = $this->have_label_file( $order );
-			$match_shipping_zones = $zone === $this->get_shipping_zone( $order );
-			$match_pickup_zone 	  = 'PICKUP' === $zone && 'NL' === $this->get_shipping_zone( $order );
+			$order_shipping_zone  = Utils::get_shipping_zone( $order->get_shipping_country(), $order->get_shipping_state() );
+			$match_shipping_zones = $zone === $order_shipping_zone;
+			$match_pickup_zone    = 'PICKUP' === $zone && 'NL' === $order_shipping_zone;
+
 			if ( $have_label_file ) {
 				$array_messages[] = array(
-			    // Translators: %1$d is the order ID.
+					// Translators: %1$d is the order ID.
 					'message' => sprintf( esc_html__( 'Order #%1$d already has a label.', 'postnl-for-woocommerce' ), $order_id ),
 					'type'    => 'error',
 				);
@@ -158,7 +160,7 @@ class Bulk extends Base {
 
 			if ( ! $match_shipping_zones && ! $match_pickup_zone ) {
 				$array_messages[] = array(
-			    // Translators: %1$d is the order ID.
+					// Translators: %1$d is the order ID.
 					'message' => sprintf( esc_html__( 'Order #%1$d is from another shipping zone.', 'postnl-for-woocommerce' ), $order_id ),
 					'type'    => 'error',
 				);

--- a/src/Order/Single.php
+++ b/src/Order/Single.php
@@ -152,7 +152,8 @@ class Single extends Base {
 		$option_map   = Mapping::option_available_list();
 		$from_country = Utils::get_base_country();
 		$to_country   = $order->get_shipping_country();
-		$destination  = Utils::get_shipping_zone( $to_country );
+		$to_state     = $order->get_shipping_state();
+		$destination  = Utils::get_shipping_zone( $to_country, $to_state );
 
 		foreach ( $meta_fields as $index => $field ) {
 			if ( isset( $field['nonce'] ) && true === $field['nonce'] ) {

--- a/src/Rest_API/Barcode/Item_Info.php
+++ b/src/Rest_API/Barcode/Item_Info.php
@@ -185,7 +185,8 @@ class Item_Info extends Base_Info {
 	 */
 	public function is_rest_of_world() {
 		$to_country  = $this->api_args['shipping_address']['country'];
-		$destination = Utils::get_shipping_zone( $to_country );
+		$to_state    = $this->api_args['shipping_address']['state'];
+		$destination = Utils::get_shipping_zone( $to_country, $to_state );
 
 		return ( 'ROW' === $destination );
 	}
@@ -197,7 +198,8 @@ class Item_Info extends Base_Info {
 	 */
 	public function is_europe() {
 		$to_country  = $this->api_args['shipping_address']['country'];
-		$destination = Utils::get_shipping_zone( $to_country );
+		$to_state    = $this->api_args['shipping_address']['state'];
+		$destination = Utils::get_shipping_zone( $to_country, $to_state );
 
 		return ( 'EU' === $destination );
 	}

--- a/src/Rest_API/Barcode/Item_Info.php
+++ b/src/Rest_API/Barcode/Item_Info.php
@@ -81,7 +81,7 @@ class Item_Info extends Base_Info {
 			'address_2'  => $order->get_shipping_address_2(),
 			'city'       => $order->get_shipping_city(),
 			'state'      => $order->get_shipping_state(),
-			'country'    => $order->get_shipping_country(),
+			'country'    => in_array( $order->get_shipping_state(), array( 'TF', 'GC' ) ) ? 'IC' : $order->get_shipping_country(),
 			'postcode'   => $order->get_shipping_postcode(),
 		);
 

--- a/src/Rest_API/Barcode/Item_Info.php
+++ b/src/Rest_API/Barcode/Item_Info.php
@@ -67,7 +67,9 @@ class Item_Info extends Base_Info {
 			);
 		}
 
-		$order = $post_data['order'];
+		$order            = $post_data['order'];
+		$shipping_country = $order->get_shipping_country();
+		$shipping_state   = $order->get_shipping_state();
 
 		if ( ! empty( $post_data['customer_code'] ) ) {
 			$this->api_args['custom']['customer_code'] = $post_data['customer_code'];
@@ -80,8 +82,8 @@ class Item_Info extends Base_Info {
 			'address_1'  => $order->get_shipping_address_1(),
 			'address_2'  => $order->get_shipping_address_2(),
 			'city'       => $order->get_shipping_city(),
-			'state'      => $order->get_shipping_state(),
-			'country'    => in_array( $order->get_shipping_state(), array( 'TF', 'GC' ) ) ? 'IC' : $order->get_shipping_country(),
+			'state'      => $shipping_state,
+			'country'    => Utils::is_canary_island( $shipping_state, $shipping_country ) ? 'IC' : $shipping_state,
 			'postcode'   => $order->get_shipping_postcode(),
 		);
 

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -878,7 +878,7 @@ class Item_Info extends Base_Info {
 		$shipping_feature = $this->get_selected_shipping_features();
 		$from_country     = $this->api_args['store_address']['country'];
 		$to_country       = $this->api_args['shipping_address']['country'];
-        $to_state         = $this->api_args['shipping_address']['state'];
+		$to_state         = $this->api_args['shipping_address']['state'];
 
 		$features = array_keys( $checked_features );
 		$code_map = Mapping::products_data();
@@ -934,8 +934,8 @@ class Item_Info extends Base_Info {
 		$option_map   = Mapping::additional_product_options();
 		$from_country = $this->api_args['store_address']['country'];
 		$to_country   = $this->api_args['shipping_address']['country'];
-		$to_state    = $this->api_args['shipping_address']['state'];
-		$destination = Utils::get_shipping_zone( $to_country, $to_state );
+		$to_state     = $this->api_args['shipping_address']['state'];
+		$destination  = Utils::get_shipping_zone( $to_country, $to_state );
 
 		foreach ( $this->api_args as $arg_keys => $arg_data ) {
 			if ( empty( $option_map[ $from_country ][ $destination ][ $arg_keys ] ) ) {

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -141,9 +141,11 @@ class Item_Info extends Base_Info {
 			);
 		}
 
-		$order        = $post_data['order'];
-		$saved_data   = $post_data['saved_data'];
-		$order_weight = $this->calculate_order_weight( $order );
+		$order            = $post_data['order'];
+		$saved_data       = $post_data['saved_data'];
+		$order_weight     = $this->calculate_order_weight( $order );
+		$shipping_country = $order->get_shipping_country();
+		$shipping_state   = $order->get_shipping_state();
 
 		$this->api_args['billing_address'] = array(
 			'first_name' => $order->get_billing_first_name(),
@@ -166,8 +168,8 @@ class Item_Info extends Base_Info {
 			'address_1'    => $order->get_shipping_address_1(),
 			'address_2'    => $order->get_shipping_address_2(),
 			'city'         => $order->get_shipping_city(),
-			'state'        => $order->get_shipping_state(),
-			'country'      => in_array( $order->get_shipping_state(), array( 'TF', 'GC' ) ) ? 'IC' : $order->get_shipping_country(),
+			'state'        => $shipping_state,
+			'country'      => Utils::is_canary_island( $shipping_state, $shipping_country ) ? 'IC' : $shipping_country,
 			'postcode'     => $order->get_shipping_postcode(),
 			'house_number' => $order->get_meta( '_shipping_house_number' ),
 		);

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -313,7 +313,8 @@ class Item_Info extends Base_Info {
 	 */
 	public function is_rest_of_world() {
 		$to_country  = $this->api_args['shipping_address']['country'];
-		$destination = Utils::get_shipping_zone( $to_country );
+		$to_state    = $this->api_args['shipping_address']['state'];
+		$destination = Utils::get_shipping_zone( $to_country, $to_state );
 
 		return ( 'ROW' === $destination );
 	}
@@ -877,13 +878,13 @@ class Item_Info extends Base_Info {
 		$shipping_feature = $this->get_selected_shipping_features();
 		$from_country     = $this->api_args['store_address']['country'];
 		$to_country       = $this->api_args['shipping_address']['country'];
+        $to_state         = $this->api_args['shipping_address']['state'];
 
 		$features = array_keys( $checked_features );
 		$code_map = Mapping::products_data();
 
 		$selected_product = array();
-		$destination      = Utils::get_shipping_zone( $to_country );
-
+		$destination      = Utils::get_shipping_zone( $to_country, $to_state );
 		if ( empty( $code_map[ $from_country ][ $destination ][ $shipping_feature ] ) ) {
 			return $selected_product;
 		}
@@ -933,7 +934,8 @@ class Item_Info extends Base_Info {
 		$option_map   = Mapping::additional_product_options();
 		$from_country = $this->api_args['store_address']['country'];
 		$to_country   = $this->api_args['shipping_address']['country'];
-		$destination  = Utils::get_shipping_zone( $to_country );
+		$to_state    = $this->api_args['shipping_address']['state'];
+		$destination = Utils::get_shipping_zone( $to_country, $to_state );
 
 		foreach ( $this->api_args as $arg_keys => $arg_data ) {
 			if ( empty( $option_map[ $from_country ][ $destination ][ $arg_keys ] ) ) {
@@ -1015,7 +1017,8 @@ class Item_Info extends Base_Info {
 		$return_label_options = Mapping::shipping_return_labels_options();
 		$from_country         = $this->api_args['store_address']['country'];
 		$to_country           = $this->api_args['shipping_address']['country'];
-		$destination          = Utils::get_shipping_zone( $to_country );
+		$to_state             = $this->api_args['shipping_address']['state'];
+		$destination          = Utils::get_shipping_zone( $to_country, $to_state );
 		$is_letterbox         = 'yes' === $this->api_args['backend_data']['letterbox'];
 		$is_return_activated  = 'yes' === $this->api_args['order_details']['is_return_activated'];
 

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -167,7 +167,7 @@ class Item_Info extends Base_Info {
 			'address_2'    => $order->get_shipping_address_2(),
 			'city'         => $order->get_shipping_city(),
 			'state'        => $order->get_shipping_state(),
-			'country'      => $order->get_shipping_country(),
+			'country'      => in_array( $order->get_shipping_state(), array( 'TF', 'GC' ) ) ? 'IC' : $order->get_shipping_country(),
 			'postcode'     => $order->get_shipping_postcode(),
 			'house_number' => $order->get_meta( '_shipping_house_number' ),
 		);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -808,6 +808,12 @@ class Utils {
 	}
 
 	/**
+     * The Canary Islands, due to the distance from mainland Spain, count as a non-EU destination from a transport point of view.
+     * This means the regular EU shipments cannot be used for these destinations,
+     * and instead the non-EU product code must be used, along with country code IC.
+     *
+     * Return true if for Spanish states "Santa Cruz de Tenerife" or "Las Palmas".
+     *
 	 * @param $state String Shipping state.
 	 * @param $country String Shipping country.
 	 *

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -380,12 +380,16 @@ class Utils {
 	 *
 	 * @return String
 	 */
-	public static function get_shipping_zone( $to_country, $to_state ) {
-		if ( 'NL' === $to_country || 'BE' === $to_country ) {
+	public static function get_shipping_zone( string $to_country, string $to_state ): string {
+		if ( in_array( $to_country, array( 'NL', 'BE' ) ) ) {
 			return $to_country;
-		} elseif ( 'TF' === $to_state || 'GC' === $to_state ) {
+		}
+
+		if ( self::is_canary_island( $to_state, $to_country ) ) {
 			return 'ROW';
-		} elseif ( in_array( $to_country, WC()->countries->get_european_union_countries(), true ) ) {
+		}
+
+		if ( in_array( $to_country, WC()->countries->get_european_union_countries(), true ) ) {
 			return 'EU';
 		}
 
@@ -801,5 +805,23 @@ class Utils {
 		}
 
 		return $filtered_infos;
+	}
+
+	/**
+	 * @param $state String Shipping state.
+	 * @param $country String Shipping country.
+	 *
+	 * @return bool
+	 */
+	public static function is_canary_island( string $state, string $country ): bool {
+		if ( 'ES' !== strtoupper( $country ) ) {
+			return false;
+		}
+
+		if ( in_array( $state, array( 'TF', 'GC' ) ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -373,15 +373,18 @@ class Utils {
 	}
 
 	/**
-	 * Get shipping zone base on the shipping country.
+	 * Get shipping zone base on the shipping country and state.
 	 *
 	 * @param String $to_country 2 digit country code.
+	 * @param String $to_state 2 digit state code.
 	 *
 	 * @return String
 	 */
-	public static function get_shipping_zone( $to_country ) {
+	public static function get_shipping_zone( $to_country, $to_state ) {
 		if ( 'NL' === $to_country || 'BE' === $to_country ) {
 			return $to_country;
+		} elseif ( 'TF' === $to_state || 'GC' === $to_state ) {
+			return 'ROW';
 		} elseif ( in_array( $to_country, WC()->countries->get_european_union_countries(), true ) ) {
 			return 'EU';
 		}
@@ -607,7 +610,7 @@ class Utils {
 	 */
 	public static function get_shipping_options( $order_id ) {
 		$order                = wc_get_order( $order_id );
-		$shipping_destination = Utils::get_shipping_zone( $order->get_shipping_country() );
+		$shipping_destination = Utils::get_shipping_zone( $order->get_shipping_country(),  $order->get_shipping_state() );
 
 		// Base shipping options (common to all destinations).
 		$base_options = array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
Task [link](https://app.clickup.com/t/8685xyjbb)
### How to test the changes in this Pull Request:

1. Create order with shipping address country "Spain" and province "Santa Cruz de Tenerife"
2. Check Delivery type from L&T tab , it should be Non EU 
3. Create label and check code , it should be 4909

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
