### PR TITLE
Add Standard shipment as a default for pickup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 * Requires at least: 4.6
 * Requires PHP: 5.6
 * Tested up to: 6.7
-* Stable tag: 5.6.3
+* Stable tag: 5.6.4
 * Requires Plugins: woocommerce
 * WC requires at least: 4.0
-* WC tested up to: 9.5
+* WC tested up to: 9.6
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 
 ## Changelog
+
+### 5.6.4
+* Fix: Add Standard Shipping to Default Shipping Pickup options.
 
 ### 5.6.3
 * Tweak: WordPress 6.7 and WooCommerce 9.5 compatibility.

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -7,11 +7,11 @@
  * Author URI: https://postnl.post/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version: 5.6.3
+ * Version: 5.6.4
  * Tested up to: 6.7
  * Requires Plugins: woocommerce
  * WC requires at least: 4.0
- * WC tested up to: 9.5
+ * WC tested up to: 9.6
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/readme.txt
+++ b/readme.txt
@@ -4,10 +4,10 @@ Tags: woocommerce, export, delivery, packages, PostNL, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.7
-Stable tag: 5.6.3
+Stable tag: 5.6.4
 Requires Plugins: woocommerce
 WC requires at least: 4.0
-WC tested up to: 9.5
+WC tested up to: 9.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 5. PostNL information on the order details page
 
 == Changelog ==
+
+= 5.6.4 (2025-02-04) =
+* Fix: Add Standard Shipping to Default Shipping Pickup options.
 
 = 5.6.3 (2025-01-06) =
 * Tweak: WordPress 6.7 and WooCommerce 9.5 compatibility.

--- a/src/Main.php
+++ b/src/Main.php
@@ -24,7 +24,7 @@ class Main {
 	 *
 	 * @var _version
 	 */
-	private $version = '5.6.3';
+	private $version = '5.6.4';
 
 	/**
 	 * The ID of this plugin settings.

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -614,6 +614,7 @@ class Settings extends \WC_Settings_API {
 				'default'     => 'id_check',
 				'for_country' => array( 'NL' ),
 				'options'     => array(
+					''         		   => esc_html__( 'Standard Shipping', 'postnl-for-woocommerce' ),
 					'id_check'         => __( 'ID Check', 'postnl-for-woocommerce' ),
 					'insured_shipping' => __( 'Insured Shipping', 'postnl-for-woocommerce' ),
 				),


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. open postnl settings , you will find a new option added to pickup


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

