### PR TITLE
Fix / Merging EU labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 * Fix: Ensure home delivery option is always visible at checkout, even if Delivery Days are disabled.
 * Fix: Labels now always include a delivery date, even for "as soon as possible" orders.
 * Add: `postnl_shipment_addresses` filter to allow third parties to modify shipping addresses and improve compatibility.
+* Fix: Merging EU Parcel product labels into a single A4 sheet with four A6 labels per page.
 
 ### 5.6.4
 * Fix: Add Standard Shipping to Default Shipping Pickup options.

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 * Fix: Ensure home delivery option is always visible at checkout, even if Delivery Days are disabled.
 * Fix: Labels now always include a delivery date, even for "as soon as possible" orders.
 * Add: `postnl_shipment_addresses` filter to allow third parties to modify shipping addresses and improve compatibility.
+* Fix: Merging EU Parcel product labels into a single A4 sheet with four A6 labels per page.
 
 = 5.6.4 (2025-02-04) =
 * Fix: Add Standard Shipping to Default Shipping Pickup options.

--- a/src/Library/CustomizedPDFMerger.php
+++ b/src/Library/CustomizedPDFMerger.php
@@ -162,20 +162,20 @@ class CustomizedPDFMerger {
 			foreach ( $file_templates as $file_template ) {
 				$rotation_needed  = false;
 				$tolerance        = 5; // Tolerance in mm for A6 only.
-				$fileWidth        = intval( $file_template['size']['width'] );
-				$fileHeight       = intval( $file_template['size']['height'] );
+				$file_width       = intval( $file_template['size']['width'] );
+				$file_height      = intval( $file_template['size']['height'] );
 				$file_orientation = $file_template['size']['orientation'];
 
 				// Check if the file matches A6 dimensions (vertical or horizontal) within tolerance.
-				$isA6 = ( abs( $fileWidth - intval( $a6_size['height'] ) ) <= $tolerance &&
-				          abs( $fileHeight - intval( $a6_size['width'] ) ) <= $tolerance )
-				        || ( abs( $fileWidth - intval( $a6_size['width'] ) ) <= $tolerance &&
-				             abs( $fileHeight - intval( $a6_size['height'] ) ) <= $tolerance );
+				$isA6 = ( abs( $file_width - intval( $a6_size['height'] ) ) <= $tolerance &&
+				          abs( $file_height - intval( $a6_size['width'] ) ) <= $tolerance )
+				        || ( abs( $file_width - intval( $a6_size['width'] ) ) <= $tolerance &&
+				             abs( $file_height - intval( $a6_size['height'] ) ) <= $tolerance );
 
 				if ( 'A6' === $label_format || ! $isA6 || 1 === count( $files ) ) {
 					$fpdi->AddPage( $file_orientation, array(
-						$fileWidth,
-						$fileHeight,
+						$file_width,
+						$file_height,
 					) );
 					$fpdi->useTemplate( $file_template['template'] );
 					$label_number = 1;
@@ -183,8 +183,8 @@ class CustomizedPDFMerger {
 				}
 
 				if (
-					$fileWidth <= ( intval( $a6_size['height'] ) + $tolerance ) &&
-					$fileHeight <= ( intval( $a6_size['width'] ) + $tolerance )
+					$file_width <= ( intval( $a6_size['height'] ) + $tolerance ) &&
+					$file_height <= ( intval( $a6_size['width'] ) + $tolerance )
 				) {
 					$rotation_needed = true;
 				}
@@ -211,14 +211,14 @@ class CustomizedPDFMerger {
 
 				// Scale A6 PDF.
 				if ( $rotation_needed ) {
-					$scaleX = $a6_size['width'] / $fileHeight;
-					$scaleY = $a6_size['height'] / $fileWidth;
+					$scale_x = $a6_size['width'] / $file_height;
+					$scale_y = $a6_size['height'] / $file_width;
 				} else {
-					$scaleX = $a6_size['width'] / $fileWidth;
-					$scaleY = $a6_size['height'] / $fileHeight;
+					$scale_x = $a6_size['width'] / $file_width;
+					$scale_y = $a6_size['height'] / $file_height;
 				}
 
-				$scale = min( $scaleX, $scaleY );
+				$scale = min( $scale_x, $scale_y );
 
 				if ( $rotation_needed ) {
 					$fpdi->Rotate( 90, 0, 0 );

--- a/src/Library/CustomizedPDFMerger.php
+++ b/src/Library/CustomizedPDFMerger.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Exception;
-use PostNLWooCommerce\Main;
 use PostNLWooCommerce\Shipping_Method\Settings;
 use PostNLWooCommerce\Utils;
 

--- a/src/Library/CustomizedPDFMerger.php
+++ b/src/Library/CustomizedPDFMerger.php
@@ -126,6 +126,14 @@ class CustomizedPDFMerger {
 		$label_number   = 1;
 		$a4_size        = Utils::get_paper_size( 'A4' );
 		$a6_size        = Utils::get_paper_size( 'A6' );
+
+		/*
+		 * Temp - Adding 1cm to handel to fix EU labels merging.
+		 * PostNL backend system generate labels with extra mm margins.
+		 */
+		$a6_size['height'] = $a6_size['height'] + 10;
+		$a6_size['width']  = $a6_size['width'] + 10;
+
 		$label_format   = $this->settings->get_label_format();
 		$first_page     = true;
 		$coordinate_map = array(
@@ -178,8 +186,8 @@ class CustomizedPDFMerger {
 
 				if (
 					count( $files ) > 1 &&
-					intval( $file_template['size']['width'] ) === intval( $a6_size['height'] )
-					&& intval( $file_template['size']['height'] ) === intval( $a6_size['width'] )
+					intval( $file_template['size']['width'] ) <= intval( $a6_size['height'] )
+					&& intval( $file_template['size']['height'] ) <= intval( $a6_size['width'] )
 				) {
 					$rotation_needed = true;
 				}
@@ -188,8 +196,8 @@ class CustomizedPDFMerger {
 					! $rotation_needed
 					&& intval( $file_template['size']['width'] ) !== intval( $a4_size['width'] )
 					&& intval( $file_template['size']['height'] ) !== intval( $a4_size['height'] )
-					&& intval( $file_template['size']['width'] ) !== intval( $a6_size['width'] )
-					&& intval( $file_template['size']['height'] ) !== intval( $a6_size['height'] )
+					&& intval( $file_template['size']['width'] ) > intval( $a6_size['width'] )
+					&& intval( $file_template['size']['height'] ) > intval( $a6_size['height'] )
 				) {
 					$fpdi->AddPage( $file_template['orientation'], array(
 						$file_template['size']['width'],

--- a/src/Library/CustomizedPDFMerger.php
+++ b/src/Library/CustomizedPDFMerger.php
@@ -164,6 +164,7 @@ class CustomizedPDFMerger {
 				$file_width       = intval( $file_template['size']['width'] );
 				$file_height      = intval( $file_template['size']['height'] );
 				$file_orientation = $file_template['size']['orientation'];
+				$is_cn23          = ( stripos( $filename, '-cn23-' ) !== false );
 
 				// Check if the file matches A6 dimensions (vertical or horizontal) within tolerance.
 				$isA6 = ( abs( $file_width - intval( $a6_size['height'] ) ) <= $tolerance &&
@@ -171,7 +172,7 @@ class CustomizedPDFMerger {
 				        || ( abs( $file_width - intval( $a6_size['width'] ) ) <= $tolerance &&
 				             abs( $file_height - intval( $a6_size['height'] ) ) <= $tolerance );
 
-				if ( 'A6' === $label_format || ! $isA6 || 1 === count( $files ) ) {
+				if ( 'A6' === $label_format || $is_cn23 || ! $isA6 || 1 === count( $files ) ) {
 					$fpdi->AddPage( $file_orientation, array(
 						$file_width,
 						$file_height,

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -15,7 +15,6 @@ use PostNLWooCommerce\Rest_API\Letterbox;
 use PostNLWooCommerce\Shipping_Method\Settings;
 use PostNLWooCommerce\Helper\Mapping;
 use PostNLWooCommerce\Library\CustomizedPDFMerger;
-use PostNLWooCommerce\Product;
 use \Imagick;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -690,8 +689,7 @@ abstract class Base {
 					$label_extension = ! empty( $label_contents['OutputType'] ) ? sanitize_title( $label_contents['OutputType'] ) : 'pdf';
 					$barcode         = $response[ $type ][ $shipment_idx ][ $content_type['barcode_key'] ];
 					$barcode         = is_array( $barcode ) ? array_shift( $barcode ) : $barcode;
-					$label_format  	 = $this->settings->get_label_format();
-					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, $label_format, $label_extension );
+					$filename        = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, 'A6', $label_extension );
 					$filepath        = trailingslashit( POSTNL_UPLOADS_DIR ) . $filename;
 
 					if ( wp_mkdir_p( POSTNL_UPLOADS_DIR ) && ! file_exists( $filepath ) ) {
@@ -910,7 +908,7 @@ abstract class Base {
 		}
 		$extension = pathinfo( $file_paths[0], PATHINFO_EXTENSION );
 
-		$filename    = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, $label_format, $extension );
+		$filename    = Utils::generate_label_name( $order->get_id(), $label_type, $barcode, $label_format . '-merged', $extension );
 		$merged_info = $this->merge_labels( $file_paths, $filename );
 
 		$merged_labels[ $label_type ] = array(
@@ -918,7 +916,7 @@ abstract class Base {
 			'barcode'      => $barcode,
 			'created_at'   => current_time( 'timestamp' ),
 			'filepath'     => $merged_info['filepath'],
-			'merged_files' => $merged_info['merged_filepaths'],
+			'merged_files' => $file_paths,
 		);
 
 		return $merged_labels;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://app.clickup.com/t/868c7j59q .

### How to test the changes in this Pull Request:

1. Add products to the cart and checkout with **EU address ( But not NL or BE )**
2. Re-do the previous step multiple times.
3. Set the Printer Type to `PDF` and label format to `A4` in the plugin settings.
4. Try to generate the labels for the new orders using bulk label.
5. the generated labels should be merged in an A4 file.
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/f6f3bbf7-ff2b-4638-b2a5-adce61306650" />


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fix: Merging EU Parcel product labels into a single A4 sheet with four A6 labels per page.

