### PR TITLE
Fix an error while trying to merge orders labels with deleted files

### DIFF
--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -928,24 +928,26 @@ abstract class Base {
 	 * @param string $merge_filename The final/merged filename with extension.
 	 * @param string $start_position Start position for the pdf file only.
 	 *
-	 * @return array|\PostNLWooCommerce\Order\Array|void
+	 * @return array
 	 */
 	protected function merge_labels( $label_paths, $merge_filename, $start_position = 'top-left' ) {
 		$extension = pathinfo( $label_paths[0], PATHINFO_EXTENSION );
-		switch ( $extension ) {
-			case 'pdf':
-				return $this->merge_pdf_labels( $label_paths, $merge_filename, $start_position );
-			case 'jpg':
-				return $this->merge_jpg_files( $label_paths, $merge_filename, 'horizontal' );
-			case 'gif':
-				try {
+
+		try {
+			switch ( $extension ) {
+				case 'pdf':
+					return $this->merge_pdf_labels( $label_paths, $merge_filename, $start_position );
+				case 'jpg':
+					return $this->merge_jpg_files( $label_paths, $merge_filename, 'horizontal' );
+				case 'gif':
 					return $this->merge_graphic_labels( $label_paths, $merge_filename );
-				} catch ( \Exception $e ) {
-					wc_add_notice( $e->getMessage(), 'error' );
-				}
-			case 'zpl_rle':
-				return $this->merge_text_files( $label_paths, $merge_filename );
+				case 'zpl_rle':
+					return $this->merge_text_files( $label_paths, $merge_filename );
+			}
+		} catch ( \Exception $e ) {
 		}
+
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

### How to test the changes in this Pull Request:
This is not a common case, but it happen when testing many orders

1. Create an order then generate a lable for it
2. Remove the pdf file from the file manager
3. try to re-download the label by the bulk

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix an error while trying to merge orders labels with deleted files
