### PR TITLE
Fix fatal error when editing pages with certain themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.7.1
+* Fixed: Fatal error when editing pages with certain themes.
+
 ### 5.7.0
 * Add: Cart/Checkout blocks compatibility.
 * Fix: Improved error messages for Shipping & Return label activation.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.7.1 (2025-xx-xx) =
+* Fixed: Fatal error when editing pages with certain themes.
+
 = 5.7.0 (2025-03-17) =
 * Add: Cart/Checkout blocks compatibility.
 * Fix: Improved error messages for Shipping & Return label activation.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -661,11 +661,15 @@ class Utils {
 	/**
 	 * Check if current cart is eligible for automatically use letterbox.
 	 *
-	 * @param \WC_Cart|int \WC_Cart.
+	 * @param \WC_Cart|null $cart Cart object.
 	 *
 	 * @return boolean
 	 */
-	public static function is_cart_eligible_auto_letterbox( $cart ) {
+	public static function is_cart_eligible_auto_letterbox( ?\WC_Cart $cart ): bool {
+		if ( is_null( $cart ) ) {
+			return false;
+		}
+
 		if ( ! in_array( WC()->customer->get_shipping_country(), self::get_available_country_for_letterbox(), true ) ) {
 			return false;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #213 .

### How to test the changes in this Pull Request:

1. Install **Enfold** theme while PostNL is active.
2. Try to edit any page ( With Gutenberg editor)
3. Edit will work fine with no errors.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fixed: Fatal error when editing pages with certain themes.

