### PR TITLE
Fix required house number for non-NL destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 ## Changelog
 
 ### 5.7.1
-* Fixed: Fatal error when editing pages with certain themes.
+* Fix: Fatal error when editing pages with certain themes.
+* Fix: Required house number for non-NL destinations in blocks checkout.
 
 ### 5.7.0
 * Add: Cart/Checkout blocks compatibility.

--- a/languages/postnl-for-woocommerce.pot
+++ b/languages/postnl-for-woocommerce.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-03-17T09:41:29+00:00\n"
+"POT-Creation-Date: 2025-03-18T11:58:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: postnl-for-woocommerce\n"
@@ -100,20 +100,17 @@ msgstr ""
 msgid "Sorry, your session has expired. <a href=\"%s\" class=\"wc-backward\">Return to shop</a>"
 msgstr ""
 
-#: src/Frontend/Checkout_Fields.php:92
-#: src/Frontend/Checkout_Fields.php:93
-#: src/Frontend/Checkout_Fields.php:117
+#: src/Frontend/Checkout_Fields.php:96
+#: src/Frontend/Checkout_Fields.php:97
 #: src/Shipping_Method/Settings.php:244
 msgid "House Number Extension"
 msgstr ""
 
-#: src/Frontend/Checkout_Fields.php:97
-#: src/Frontend/Checkout_Fields.php:121
+#: src/Frontend/Checkout_Fields.php:101
 msgid "Street"
 msgstr ""
 
-#: src/Frontend/Checkout_Fields.php:98
-#: src/Frontend/Checkout_Fields.php:122
+#: src/Frontend/Checkout_Fields.php:102
 msgid "Street Name"
 msgstr ""
 
@@ -602,12 +599,12 @@ msgid "Order ID does not exist!"
 msgstr ""
 
 #: src/Rest_API/Barcode/Item_Info.php:136
-#: src/Rest_API/Shipping/Item_Info.php:342
+#: src/Rest_API/Shipping/Item_Info.php:339
 msgid "Customer Code is empty!"
 msgstr ""
 
 #: src/Rest_API/Barcode/Item_Info.php:139
-#: src/Rest_API/Shipping/Item_Info.php:345
+#: src/Rest_API/Shipping/Item_Info.php:342
 msgid "Customer Number is empty!"
 msgstr ""
 
@@ -686,116 +683,116 @@ msgstr ""
 msgid "Missing barcode"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:339
+#: src/Rest_API/Shipping/Item_Info.php:336
 msgid "Location Code is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:354
+#: src/Rest_API/Shipping/Item_Info.php:351
 msgid "Store email is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:360
+#: src/Rest_API/Shipping/Item_Info.php:357
 msgid "Wrong format for store email!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:415
+#: src/Rest_API/Shipping/Item_Info.php:412
 msgid "Order ID is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:418
+#: src/Rest_API/Shipping/Item_Info.php:415
 msgid "Order number is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:421
+#: src/Rest_API/Shipping/Item_Info.php:418
 msgid "Barcode is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:433
+#: src/Rest_API/Shipping/Item_Info.php:430
 msgid "Product code is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:437
+#: src/Rest_API/Shipping/Item_Info.php:434
 msgid "Wrong format for product code!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:474
+#: src/Rest_API/Shipping/Item_Info.php:471
 msgid "Total weight is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:489
+#: src/Rest_API/Shipping/Item_Info.php:486
 msgid "Customer email is not valid!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:498
+#: src/Rest_API/Shipping/Item_Info.php:495
 msgid "Currency is not available!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:525
+#: src/Rest_API/Shipping/Item_Info.php:522
 msgid "Delivery day \"Date\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:541
+#: src/Rest_API/Shipping/Item_Info.php:538
 msgid "Delivery day \"From\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:554
+#: src/Rest_API/Shipping/Item_Info.php:551
 msgid "Delivery day \"To\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:570
+#: src/Rest_API/Shipping/Item_Info.php:567
 msgid "Delivery day \"Type\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:594
+#: src/Rest_API/Shipping/Item_Info.php:591
 msgid "Pickup \"Date\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:610
+#: src/Rest_API/Shipping/Item_Info.php:607
 msgid "Pickup \"Time\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:622
+#: src/Rest_API/Shipping/Item_Info.php:619
 msgid "Pickup \"Company name\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:631
+#: src/Rest_API/Shipping/Item_Info.php:628
 msgid "Pickup \"Address 1\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:646
+#: src/Rest_API/Shipping/Item_Info.php:643
 msgid "Pickup Point \"City\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:655
+#: src/Rest_API/Shipping/Item_Info.php:652
 msgid "Pickup Point \"Postcode\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:667
+#: src/Rest_API/Shipping/Item_Info.php:664
 msgid "Pickup Point \"Country\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:795
+#: src/Rest_API/Shipping/Item_Info.php:792
 msgid "Item HS Code must be between 6 and 20 characters long"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:808
+#: src/Rest_API/Shipping/Item_Info.php:805
 msgid "Item \"Product ID\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:811
+#: src/Rest_API/Shipping/Item_Info.php:808
 msgid "Item \"Product SKU\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:828
+#: src/Rest_API/Shipping/Item_Info.php:825
 msgid "Item quantity must be more than 1"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:1008
+#: src/Rest_API/Shipping/Item_Info.php:1005
 msgid "Max weight for Mailbox Packet is 2kg!"
 msgstr ""
 
 #. Translators: %s is the order total.
-#: src/Rest_API/Shipping/Item_Info.php:1032
+#: src/Rest_API/Shipping/Item_Info.php:1029
 msgid "Insurance amount for EU shipments cannot exceed €5000. Your total is: %d"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,8 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 == Changelog ==
 
 = 5.7.1 (2025-xx-xx) =
-* Fixed: Fatal error when editing pages with certain themes.
+* Fix: Fatal error when editing pages with certain themes.
+* Fix: Required house number for non-NL destinations in blocks checkout.
 
 = 5.7.0 (2025-03-17) =
 * Add: Cart/Checkout blocks compatibility.

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -218,7 +218,7 @@ class Extend_Block_Core {
 		/**
 		 * Save the order to persist changes
 		 */
-		$order->save();
+		$order->save_meta_data();
 	}
 
 

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -64,7 +64,7 @@ class Extend_Block_Core {
 		if ( $invalid_marker ) {
 			$errors->add(
 				'invalid_address',
-				__( 'This is not a valid address!', 'postnl-for-woocommerce' )
+				esc_html__( 'This is not a valid address!', 'postnl-for-woocommerce' )
 			);
 		}
 	}
@@ -81,9 +81,9 @@ class Extend_Block_Core {
 						'id'         => 'postnl/house_number',
 						'label'      => __( 'House number', 'postnl-for-woocommerce' ),
 						'location'   => 'address',
-						'required'   => true,
+						'required'   => false,
 						'attributes' => array(
-							'autocomplete' => 'house-number',
+							'autocomplete' => 'house_number',
 						),
 					),
 				);

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -69,120 +69,187 @@ class Extend_Store_Endpoint {
 	 *
 	 * @return array Schema structure.
 	 */
-	public static function extend_checkout_schema() {
+	public static function extend_checkout_schema(): array {
 		return array(
 			'houseNumber'                 => array(
 				'description' => 'Shipping house number PostNL',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'deliveryDay'                 => array(
 				'description' => 'Selected delivery day for PostNL',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'deliveryDayDate'             => array(
 				'description' => 'Selected delivery day date for PostNL',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'deliveryDayFrom'             => array(
 				'description' => 'Delivery start time for PostNL delivery day',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'deliveryDayTo'               => array(
 				'description' => 'Delivery end time for PostNL delivery day',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'deliveryDayPrice'            => array(
 				'description' => 'Price for the selected PostNL delivery time',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
+				'type'        => 'string',
 			),
 			'deliveryDayType'             => array(
 				'description' => 'Type of delivery (Morning, Evening, etc.) for PostNL delivery day',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
-			// Updated hidden fields for the drop-off point
 			'dropoffPoints'               => array(
 				'description' => 'Selected drop-off point identifier',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsAddressCompany' => array(
 				'description' => 'Company name of the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsAddress1'       => array(
 				'description' => 'Address line 1 of the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsAddress2'       => array(
 				'description' => 'Address line 2 of the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsCity'           => array(
 				'description' => 'City of the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsPostcode'       => array(
 				'description' => 'Postcode of the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsCountry'        => array(
 				'description' => 'Country of the drop-off point',
-				// Use 'country' format if applicable
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsPartnerID'      => array(
 				'description' => 'Partner ID of the drop-off point',
-				// Change to 'number' if it's numeric
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsDate'           => array(
 				'description' => 'Date of the drop-off point selection',
-				// Use 'date' format if applicable
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsTime'           => array(
 				'description' => 'Time of the drop-off point selection',
-				// Use 'time' format if applicable
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => '',
+				'type'        => 'string',
 			),
 			'dropoffPointsDistance'       => array(
 				'description' => 'Distance to the drop-off point',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => array(
+					'view',
+					'edit'
+				),
 				'readonly'    => false,
 				'default'     => 0.0,
 				'nullable'    => true,
+				'type'        => array( 'string', 'null' ),
 			),
 		);
 	}

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -178,7 +178,7 @@ class Extend_Store_Endpoint {
 				),
 				'readonly'    => false,
 				'default'     => '',
-				'type'        => 'string',
+				'type'        => array( 'number', 'string' ),
 			),
 			'dropoffPointsCity'           => array(
 				'description' => 'City of the drop-off point',
@@ -249,7 +249,7 @@ class Extend_Store_Endpoint {
 				'readonly'    => false,
 				'default'     => 0.0,
 				'nullable'    => true,
-				'type'        => array( 'string', 'null' ),
+				'type'        => array( 'string', 'number', 'null' ),
 			),
 		);
 	}

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -79,7 +79,7 @@ class Extend_Store_Endpoint {
 				),
 				'readonly'    => false,
 				'default'     => '',
-				'type'        => 'string',
+				'type'        => array( 'string', 'integer' ),
 			),
 			'deliveryDay'                 => array(
 				'description' => 'Selected delivery day for PostNL',

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -39,14 +39,16 @@ class Checkout_Fields {
 	 * Collection of hooks when initiation.
 	 */
 	public function init_hooks() {
-		if ( $this->settings->is_reorder_nl_address_enabled() ) {
-			if ( ! $this->is_blocks_checkout() ) {
-				add_filter( 'woocommerce_default_address_fields', array( $this, 'add_house_number' ) );
-			}
-
-			add_filter( 'woocommerce_get_country_locale', array( $this, 'get_country_locale' ) );
-			add_filter( 'woocommerce_country_locale_field_selectors', array( $this, 'country_locale_field_selectors' ) );
+		if ( ! $this->settings->is_reorder_nl_address_enabled() ) {
+			return;
 		}
+
+		if ( ! $this->is_blocks_checkout() ) {
+			add_filter( 'woocommerce_default_address_fields', array( $this, 'add_house_number' ) );
+		}
+
+		add_filter( 'woocommerce_get_country_locale', array( $this, 'get_country_locale' ) );
+		add_filter( 'woocommerce_country_locale_field_selectors', array( $this, 'country_locale_field_selectors' ) );
 	}
 
 	/**

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -84,8 +84,6 @@ class Checkout_Fields {
 			$house_number_key = 'house_number';
 		}
 
-		error_log($house_number_key);
-
 		$fields_to_order = array(
 			'first_name'      => array( 'priority' => 1 ),
 			'last_name'       => array( 'priority' => 2 ),

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -121,8 +121,8 @@ class Checkout_Fields {
 			$countries_codes = array_keys( WC()->countries->get_countries() );
 			foreach ( $countries_codes as $country_code ) {
 				if ( 'NL' !== $country_code ) {
-					$checkout_fields[ $country_code ][$house_number_key]['hidden']   = true;
-					$checkout_fields[ $country_code ][$house_number_key]['required'] = false;
+					$checkout_fields[ $country_code ][ $house_number_key ]['hidden']   = true;
+					$checkout_fields[ $country_code ][ $house_number_key ]['required'] = false;
 				}
 			}
 		}

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -39,7 +39,7 @@ class Checkout_Fields {
 	 * Collection of hooks when initiation.
 	 */
 	public function init_hooks() {
-		if ( ! $this->settings->is_reorder_nl_address_enabled() ) {
+		if ( ! $this->settings->is_reorder_nl_address_enabled() && ! $this->is_blocks_checkout() ) {
 			return;
 		}
 

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -108,6 +108,10 @@ class Checkout_Fields {
 			'city'            => array( 'priority' => 9 ),
 		);
 
+		if ( $is_blocks_checkout ) {
+			unset( $fields_to_order['company'] );
+		}
+
 		foreach ( $fields_to_order as $field_key => $field ) {
 			foreach ( $field as $override => $value ) {
 				$checkout_fields['NL'][ $field_key ][ $override ] = $value;

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -171,10 +171,7 @@ class Item_Info extends Base_Info {
 			'state'        => $shipping_state,
 			'country'      => Utils::is_canary_island( $shipping_state, $shipping_country ) ? 'IC' : $shipping_country,
 			'postcode'     => $order->get_shipping_postcode(),
-			'house_number' => $order->get_meta( '_shipping_house_number' )
-				? $order->get_meta( '_shipping_house_number' )
-				: $order->get_meta( '_wc_billing/postnl/house_number' ),
-
+			'house_number' => $order->get_meta( '_shipping_house_number' ),
 		);
 
 		// Check the house number.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
* Fix: Required house number for non-NL destinations in blocks checkout.
* Fix PHP warnings

### How to test the changes in this Pull Request:

1. Add products to the cart
2. Make sure you are using Blocks checkout
3. Checkout and change the shipping address to any country but not NL.
4. it should work without "House number is required" error.
5. Check the error logs, it should be empty.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fix: Required house number for non-NL destinations in blocks checkout.

