### PR TITLE
Fix/ Checkout not working properly with PostNL Address Fields disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.7.2
+* Fix: Checkout not working properly with PostNL Address Fields disabled.
+
 ### 5.7.1
 * Fix: Fatal error when editing pages with certain themes.
 * Fix: Required house number for non-NL destinations in blocks checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.7.2 (2025-xx-xx) =
+* Fix: Checkout not working properly with PostNL Address Fields disabled.
+
 = 5.7.1 (2025-03-19) =
 * Fix: Fatal error when editing pages with certain themes.
 * Fix: Required house number for non-NL destinations in blocks checkout.

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -203,6 +203,7 @@ class Blocks_Integration implements IntegrationInterface {
 			'nonce'     => wp_create_nonce( 'postnl_delivery_day_nonce' ),
 			'letterbox' => $letterbox,
 			'is_nl_address_enabled' => $settings->is_reorder_nl_address_enabled(),
+			'is_pickup_points_enabled' => $settings->is_pickup_points_enabled(),
 		);
 	}
 }

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -4,6 +4,7 @@ namespace PostNLWooCommerce\Checkout_Blocks;
 
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 use PostNLWooCommerce\Utils;
+use function PostNLWooCommerce\postnl;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -194,12 +195,14 @@ class Blocks_Integration implements IntegrationInterface {
 	 */
 	public function get_script_data() {
 		$letterbox = Utils::is_cart_eligible_auto_letterbox( WC()->cart );
+		$settings = postnl()->get_shipping_settings();
 
 		return array(
 			'pluginUrl' => POSTNL_WC_PLUGIN_DIR_URL,
 			'ajax_url'  => admin_url( 'admin-ajax.php' ),
 			'nonce'     => wp_create_nonce( 'postnl_delivery_day_nonce' ),
-			'letterbox' => $letterbox, // Add the letterbox status here
+			'letterbox' => $letterbox,
+			'is_nl_address_enabled' => $settings->is_reorder_nl_address_enabled(),
 		);
 	}
 }

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -198,11 +198,11 @@ class Blocks_Integration implements IntegrationInterface {
 		$settings = postnl()->get_shipping_settings();
 
 		return array(
-			'pluginUrl' => POSTNL_WC_PLUGIN_DIR_URL,
-			'ajax_url'  => admin_url( 'admin-ajax.php' ),
-			'nonce'     => wp_create_nonce( 'postnl_delivery_day_nonce' ),
-			'letterbox' => $letterbox,
-			'is_nl_address_enabled' => $settings->is_reorder_nl_address_enabled(),
+			'pluginUrl'                => POSTNL_WC_PLUGIN_DIR_URL,
+			'ajax_url'                 => admin_url( 'admin-ajax.php' ),
+			'nonce'                    => wp_create_nonce( 'postnl_delivery_day_nonce' ),
+			'letterbox'                => $letterbox,
+			'is_nl_address_enabled'    => $settings->is_reorder_nl_address_enabled(),
 			'is_pickup_points_enabled' => $settings->is_pickup_points_enabled(),
 		);
 	}

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -362,7 +362,6 @@ class Extend_Block_Core {
 		// Proceed to fetch delivery and dropoff options
 		$order_data = $sanitized_data;
 
-		$container        = new Container();
 		$delivery_day     = new Delivery_Day();
 		$dropoff          = new Dropoff_Points();
 		$checkout_data    = $container->get_checkout_data( $order_data );

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -278,6 +278,7 @@ class Extend_Block_Core {
 		// If not NL, clear session and return
 		if ( ! in_array( $shipping_country, array( 'NL', 'BE' ), true ) ) {
 			WC()->session->__unset( 'postnl_checkout_post_data' );
+			WC()->session->__unset( POSTNL_SETTINGS_ID . '_invalid_address_marker' );
 			wp_send_json_success(
 				array(
 					'message'          => 'No delivery options available outside NL.',
@@ -324,9 +325,10 @@ class Extend_Block_Core {
 		// Retrieve validated address from session
 		$validated_address = WC()->session->get( POSTNL_SETTINGS_ID . '_validated_address' );
 
+		$container = new Container();
+
 		// If validation is enabled and address changed or not validated yet
-		if ( $this->settings->is_validate_nl_address_enabled() && ( $address_changed || empty( $validated_address ) ) ) {
-			$container = new Container();
+		if ( $container->is_address_validation_required() && 'NL' == $shipping_country && ( $address_changed || empty( $validated_address ) ) ) {
 			try {
 				$container->validated_address( $sanitized_data );
 				// Attempt to fetch validated address again

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -183,7 +183,7 @@ class Extend_Block_Core {
 		// Extract billing and shipping house numbers with sanitization
 		$shipping_house_number = '';
 
-		if ( ! empty( $postnl_request_data['houseNumber'] ) && $this->settings->is_reorder_nl_address_enabled()) {
+		if ( ! empty( $postnl_request_data['houseNumber'] ) && $this->settings->is_reorder_nl_address_enabled() ) {
 			$shipping_house_number = sanitize_text_field( $postnl_request_data['houseNumber'] );
 		}
 		// Update billing and shipping house numbers

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -184,14 +184,9 @@ class Extend_Block_Core {
 		// Extract billing and shipping house numbers with sanitization
 		$shipping_house_number = '';
 
-		if ( ! empty( $postnl_request_data['houseNumber'] ) ) {
+		if ( ! empty( $postnl_request_data['houseNumber'] ) && $this->settings->is_reorder_nl_address_enabled()) {
 			$shipping_house_number = sanitize_text_field( $postnl_request_data['houseNumber'] );
-		} elseif ( ! empty( WC()->session->get( 'postnl_extracted_house_number', '' ) ) ) {
-			$shipping_house_number = WC()->session->get( 'postnl_extracted_house_number', '' );
-		} else {
-			$shipping_house_number = '';
 		}
-
 		// Update billing and shipping house numbers
 		$order->update_meta_data( '_shipping_house_number', $shipping_house_number );
 
@@ -265,11 +260,6 @@ class Extend_Block_Core {
 
 		$sanitized_data = Address_Utils::set_post_data_address( $sanitized_data );
 
-		// Store the parsed house number in the session if the field was disabled
-		if(!$this->settings->is_reorder_nl_address_enabled()){
-			$shipping_house_number = $sanitized_data['shipping_house_number'] ?? '';
-			WC()->session->set( 'postnl_extracted_house_number', $shipping_house_number );
-		}
 
 		$shipping_country = isset( $sanitized_data['shipping_country'] ) ? $sanitized_data['shipping_country'] : '';
 

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -327,7 +327,7 @@ class Extend_Block_Core {
 		$container = new Container();
 
 		// If validation is enabled and address changed or not validated yet
-		if ( $container->is_address_validation_required() && 'NL' == $shipping_country && ( $address_changed || empty( $validated_address ) ) ) {
+		if ( $container->is_address_validation_required() && 'NL' === $shipping_country && ( $address_changed || empty( $validated_address ) ) ) {
 			try {
 				$container->validated_address( $sanitized_data );
 				// Attempt to fetch validated address again

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -54,7 +54,6 @@ class Extend_Block_Core {
 		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'postnl_add_custom_fee' ) );
 		if ( $this->settings->is_reorder_nl_address_enabled() ) {
 			$this->register_additional_checkout_fields();
-
 		}
 
 		// Validate adress in cart

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -302,7 +302,7 @@ class Extend_Block_Core {
 				WC()->session->__unset( 'postnl_checkout_post_data' );
 			wp_send_json_success(
 				array(
-					'message'          => 'Postcode or house number is missing.',
+					'message'          => esc_html__( 'Postcode or house number is missing.', 'postnl-for-woocommerce' ),
 					'show_container'   => false,
 					'delivery_options' => array(),
 					'dropoff_options'  => array(),

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -72,7 +72,7 @@ class Extend_Store_Endpoint {
 	 */
 	public static function extend_checkout_schema(): array {
 
-		$schema = [];
+		$schema = array();
 
 		$settings = postnl()->get_shipping_settings();
 

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -7,6 +7,7 @@
 
 namespace PostNLWooCommerce\Checkout_Blocks;
 
+use function PostNLWooCommerce\postnl;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
@@ -70,17 +71,26 @@ class Extend_Store_Endpoint {
 	 * @return array Schema structure.
 	 */
 	public static function extend_checkout_schema(): array {
-		return array(
-			'houseNumber'                 => array(
+
+		$schema = [];
+
+		$settings = postnl()->get_shipping_settings();
+		$log_file = WP_CONTENT_DIR . '/postnl-response-log.txt'; // Path to the log file
+		$log_data = json_encode( $settings->is_reorder_nl_address_enabled(), JSON_PRETTY_PRINT );
+		// Append the log data to the file
+		//file_put_contents( $log_file, $log_data . PHP_EOL, FILE_APPEND );
+
+		if ( $settings && $settings->is_reorder_nl_address_enabled() ) {
+			$schema['houseNumber'] = array(
 				'description' => 'Shipping house number PostNL',
-				'context'     => array(
-					'view',
-					'edit'
-				),
+				'context'     => array( 'view', 'edit' ),
 				'readonly'    => false,
-				'default'     => '',
-				'type'        => array( 'string', 'integer' ),
-			),
+				'default'     => null,
+				'nullable'    => true,
+				'type'        => array( 'string', 'integer', 'null' ),
+			);
+		}
+		$schema += array(
 			'deliveryDay'                 => array(
 				'description' => 'Selected delivery day for PostNL',
 				'context'     => array(
@@ -140,7 +150,7 @@ class Extend_Store_Endpoint {
 				'default'     => '',
 				'type'        => 'string',
 			),
-			'dropoffPoints'               => array(
+			'dropoffPoints' => array(
 				'description' => 'Selected drop-off point identifier',
 				'context'     => array(
 					'view',
@@ -252,5 +262,6 @@ class Extend_Store_Endpoint {
 				'type'        => array( 'string', 'number', 'null' ),
 			),
 		);
+		return $schema;
 	}
 }

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -75,10 +75,6 @@ class Extend_Store_Endpoint {
 		$schema = [];
 
 		$settings = postnl()->get_shipping_settings();
-		$log_file = WP_CONTENT_DIR . '/postnl-response-log.txt'; // Path to the log file
-		$log_data = json_encode( $settings->is_reorder_nl_address_enabled(), JSON_PRETTY_PRINT );
-		// Append the log data to the file
-		//file_put_contents( $log_file, $log_data . PHP_EOL, FILE_APPEND );
 
 		if ( $settings && $settings->is_reorder_nl_address_enabled() ) {
 			$schema['houseNumber'] = array(

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -84,6 +84,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 		return (
 			addr1.country === addr2.country &&
 			addr1.postcode === addr2.postcode &&
+			addr1.address_1 === addr2.address_1 &&
 			addr1[ 'postnl/house_number' ] === addr2[ 'postnl/house_number' ]
 		);
 	};

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -70,7 +70,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 	const currentHouseNumber = shippingAddress?.[ 'postnl/house_number' ] || '';
 
 	useEffect( () => {
-		if ( currentHouseNumber ) {
+		if ( currentHouseNumber && postnlData.is_nl_address_enabled && false) {
 			setExtensionData( 'postnl', 'houseNumber', currentHouseNumber );
 		}
 	}, [ shippingAddress, setExtensionData ] );
@@ -93,7 +93,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			! shippingAddress ||
 			empty( shippingAddress.postcode ) ||
 			( shippingAddress.country === 'NL' &&
-				empty( shippingAddress[ 'postnl/house_number' ] ) )
+				(postnlData.is_nl_address_enabled && empty( shippingAddress[ 'postnl/house_number' ] )) )
 		) {
 			// If we have no valid postcode/house number, hide container
 			setShowContainer( false );
@@ -120,8 +120,12 @@ export const Block = ( { checkoutExtensionData } ) => {
 			const data = {
 				shipping_country: shippingAddress.country || '',
 				shipping_postcode: shippingAddress.postcode || '',
-				shipping_house_number:
-					shippingAddress[ 'postnl/house_number' ] || '',
+				...( postnlData.is_nl_address_enabled
+					? {
+						shipping_house_number:
+							shippingAddress[ 'postnl/house_number' ] || '',
+					}
+					: {} ),
 				shipping_address_2: shippingAddress.address_2 || '',
 				shipping_address_1: shippingAddress.address_1 || '',
 				shipping_city: shippingAddress.city || '',
@@ -278,6 +282,18 @@ export const Block = ( { checkoutExtensionData } ) => {
 			'deliveryDayType',
 			firstOption.type || 'Letterbox'
 		);
+		setExtensionData( 'postnl', 'dropoffPoints', '' );
+		setExtensionData( 'postnl', 'dropoffPointsAddressCompany', '' );
+		setExtensionData( 'postnl', 'dropoffPointsAddress1', '' );
+		setExtensionData( 'postnl', 'dropoffPointsAddress2', '' );
+		setExtensionData( 'postnl', 'dropoffPointsCity', '' );
+		setExtensionData( 'postnl', 'dropoffPointsPostcode', '' );
+		setExtensionData( 'postnl', 'dropoffPointsCountry', '' );
+		setExtensionData( 'postnl', 'dropoffPointsPartnerID', '' );
+		setExtensionData( 'postnl', 'dropoffPointsDate', '' );
+		setExtensionData( 'postnl', 'dropoffPointsTime', '' );
+		setExtensionData( 'postnl', 'dropoffPointsDistance', '' );
+
 	}, [ letterbox, showContainer, deliveryOptions, setExtensionData ] );
 
 	return (

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -16,21 +16,22 @@ import { Block as DropoffPointsBlock } from '../postnl-dropoff-points/block';
 
 export const Block = ( { checkoutExtensionData } ) => {
 	const { setExtensionData } = checkoutExtensionData;
+	const postnlData = getSetting( 'postnl-for-woocommerce-blocks_data', {} );
 
 	const tabs = [
 		{
 			id: 'delivery_day',
 			name: __( 'Delivery Days', 'postnl-for-woocommerce' ),
 		},
-		{
+	];
+	if ( postnlData.is_pickup_points_enabled ) {
+		tabs.push({
 			id: 'dropoff_points',
 			name: __( 'Dropoff Points', 'postnl-for-woocommerce' ),
-		},
-	];
-
+		});
+	}
 	const [ activeTab, setActiveTab ] = useState( tabs[ 0 ].id );
 
-	const postnlData = getSetting( 'postnl-for-woocommerce-blocks_data', {} );
 	const letterbox = postnlData.letterbox || false;
 	const { CART_STORE_KEY, CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
 
@@ -373,18 +374,20 @@ export const Block = ( { checkoutExtensionData } ) => {
 								isDeliveryDaysEnabled={ deliveryDaysEnabled }
 							/>
 						</div>
-						<div
-							className={ `postnl_content ${
-								activeTab === 'dropoff_points' ? 'active' : ''
-							}` }
-							id="postnl_dropoff_points_content"
-						>
-							<DropoffPointsBlock
-								checkoutExtensionData={ checkoutExtensionData }
-								isActive={ activeTab === 'dropoff_points' }
-								dropoffOptions={ dropoffOptions }
-							/>
-						</div>
+						{ postnlData.is_pickup_points_enabled && (
+							<div
+								className={ `postnl_content ${
+									activeTab === 'dropoff_points' ? 'active' : ''
+								}` }
+								id="postnl_dropoff_points_content"
+							>
+								<DropoffPointsBlock
+									checkoutExtensionData={ checkoutExtensionData }
+									isActive={ activeTab === 'dropoff_points' }
+									dropoffOptions={ dropoffOptions }
+								/>
+							</div>
+						) }
 					</div>
 				</>
 			) }

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -168,16 +168,21 @@ export const Block = ( { checkoutExtensionData } ) => {
 								respData.validated_address;
 							const newShippingAddress = {
 								...shippingAddress,
-								address_1: street,
 								city,
 								'postnl/house_number': house_number,
 							};
 
+							if ( ! postnlData.is_nl_address_enabled ) {
+								newShippingAddress.address_1 = `${street} ${house_number}`;
+							} else {
+								newShippingAddress.address_1 = street;
+							}
+
 							if (
-								shippingAddress.address_1 !== street ||
+								(shippingAddress.address_1 !== street ||
 								shippingAddress.city !== city ||
 								shippingAddress[ 'postnl/house_number' ] !==
-									house_number
+									house_number)
 							) {
 								isUpdatingAddress.current = true;
 								setShippingAddress( newShippingAddress );

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -71,7 +71,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 	const currentHouseNumber = shippingAddress?.[ 'postnl/house_number' ] || '';
 
 	useEffect( () => {
-		if ( currentHouseNumber && postnlData.is_nl_address_enabled && false) {
+		if ( currentHouseNumber && postnlData.is_nl_address_enabled) {
 			setExtensionData( 'postnl', 'houseNumber', currentHouseNumber );
 		}
 	}, [ shippingAddress, setExtensionData ] );

--- a/src/Checkout_Blocks/js/postnl-delivery-day/block.js
+++ b/src/Checkout_Blocks/js/postnl-delivery-day/block.js
@@ -230,6 +230,11 @@ export const Block = ( {
 						{ deliveryOptions.map( ( delivery, index ) => {
 							return (
 								<li key={ index }>
+									{ isDeliveryDaysEnabled && (
+										<div className="list_title">
+											<span>{ delivery.date } { delivery.day }</span>
+										</div>
+									) }
 									<ul className="postnl_sub_list">
 										{ delivery.options.map(
 											( option, optionIndex ) => {

--- a/src/Frontend/Checkout_Fields.php
+++ b/src/Frontend/Checkout_Fields.php
@@ -39,7 +39,7 @@ class Checkout_Fields {
 	 * Collection of hooks when initiation.
 	 */
 	public function init_hooks() {
-		if ( ! $this->settings->is_reorder_nl_address_enabled() && ! $this->is_blocks_checkout() ) {
+		if ( ! $this->settings->is_reorder_nl_address_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes [#868cy7gh3](https://app.clickup.com/t/868cy7gh3).

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Shipping > PostNL
2. Disable "Use PostNL address-field"
3. Add products to the cart then checkout, PostNL should work fine for both blocs and classic checkout.

<img width="1445" alt="image" src="https://github.com/user-attachments/assets/1a6edc8f-5b48-45bf-a318-2c06c5adce10" />



### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Checkout not working properly with PostNL Address Fields disabled.
