### PR TITLE
include the single label in the merging process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Tested up to: 6.7
 * WC requires at least: 9.5
 * WC tested up to: 9.7
-* Stable tag: 5.7.1
+* Stable tag: 5.7.2
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postnl-for-woocommerce",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postnl-for-woocommerce",
-      "version": "5.7.1",
+      "version": "5.7.2",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@woocommerce/date": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postnl-for-woocommerce",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "author": "The WordPress Contributors",
   "license": "GPL-2.0-or-later",
   "main": "build/index.js",

--- a/postnl-for-woocommerce.php
+++ b/postnl-for-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI: https://postnl.post/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Version: 5.7.1
+ * Version: 5.7.2
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.6

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.7.2 (2025-04-22) =
+Fix: Single label now printed according to the selected start position.
+
 = 5.7.1 (2025-03-19) =
 * Fix: Fatal error when editing pages with certain themes.
 * Fix: Required house number for non-NL destinations in blocks checkout.

--- a/src/Library/CustomizedPDFMerger.php
+++ b/src/Library/CustomizedPDFMerger.php
@@ -172,7 +172,7 @@ class CustomizedPDFMerger {
 						|| ( abs( $file_width - intval( $a6_size['width'] ) ) <= $tolerance &&
 							abs( $file_height - intval( $a6_size['height'] ) ) <= $tolerance );
 
-				if ( 'A6' === $label_format || $is_cn23 || ! $isA6 || 1 === count( $files ) ) {
+				if ( 'A6' === $label_format || $is_cn23 || ! $isA6 ) {
 					$fpdi->AddPage(
 						$file_orientation,
 						array(

--- a/src/Main.php
+++ b/src/Main.php
@@ -27,7 +27,7 @@ class Main {
 	 *
 	 * @var _version
 	 */
-	private $version = '5.7.1';
+	private $version = '5.7.2';
 
 	/**
 	 * The ID of this plugin settings.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create a new order.
2. Open admin order list page.
3. Select the order then from Bulk actions select "PostNL Create Label".
4. Set Number of Labels: 1, uncheck Create Return Label and select "Bottom left" from Start position printing label then submit 
5.  Label will be generated at the bottom left of the page


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix: Single-label orders now honor the selected start position.