### PR TITLE
Fix/cut off time defaultl value

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.7.2
+* Fix: Single label now printed according to the selected start position.
+* Fix: Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
+
 ### 5.7.1
 * Fix: Fatal error when editing pages with certain themes.
 * Fix: Required house number for non-NL destinations in blocks checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -81,8 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
-= 5.7.2 (2025-04-22) =
-Fix: Single label now printed according to the selected start position.
+= 5.7.2 ( 2025-xx-xx ) =
+* Fix: Single label now printed according to the selected start position.
+* Fix: Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
 
 = 5.7.1 (2025-03-19) =
 * Fix: Fatal error when editing pages with certain themes.

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
-= 5.7.2 ( 2025-xx-xx ) =
+= 5.7.2 (2025-xx-xx) =
 * Fix: Single label now printed according to the selected start position.
 * Fix: Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
 

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -382,7 +382,7 @@ class Settings extends \WC_Settings_API {
 				'type'        => 'time',
 				'description' => esc_html__( 'If an order is ordered after this time, one day will be added to the transit time.', 'postnl-for-woocommerce' ),
 				'desc_tip'    => true,
-				'default'     => '18',
+				'default'     => '18:00',
 				'placeholder' => '',
 			),
 			'dropoff_day_mon'                 => array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://wordpress.org/support/topic/error-wrong-format-for-cut-off-time/#post-18431304

### How to test the changes in this Pull Request:

1. Install PostNL plugin in a fresh WordPress installation.
2. Setup the plugin without modifying the cut-off setting field.
3. Add products to cart and go to checkout, it should work normally.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
