### PR TITLE
Register shipping method on `plugins_loaded` level

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -82,9 +82,10 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 == Changelog ==
 
 = 5.7.2 (2025-xx-xx) =
-* Fix: Single label now printed according to the selected start position.
-* Fix: Checkout not working properly with PostNL Address Fields disabled.
-* Fix: Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
+* Fix   : Single label now printed according to the selected start position.
+* Fix   : Checkout not working properly with PostNL Address Fields disabled.
+* Fix   : Cut Off time default value to prevent "Wrong format for cut off time!" checkout error for new installations.
+* Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.
 
 = 5.7.1 (2025-03-19) =
 * Fix: Fatal error when editing pages with certain themes.

--- a/src/Main.php
+++ b/src/Main.php
@@ -97,11 +97,26 @@ class Main {
 	 * Construct the plugin.
 	 */
 	public function __construct() {
+		$this->define_constants();
+		// Throw an admin error informing the user this plugin needs WooCommerce to function.
+		add_action( 'admin_notices', array( $this, 'notice_wc_required' ) );
+
+		// Throw an admin error informing the user this plugin needs country settings to be NL and BE.
+		add_action( 'admin_notices', array( $this, 'notice_nl_be_required' ) );
+
+		// Throw an admin error informing the user this plugin needs currency settings to be EUR, USD, GBP, CNY.
+		add_action( 'admin_notices', array( $this, 'notice_currency_required' ) );
+
+		if ( ! class_exists( 'WooCommerce' ) || ! Utils::use_available_currency() || ! Utils::use_available_country() ) {
+			return;
+		}
+
 		add_action( 'init', array( $this, 'load_plugin' ), 1 );
 		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_hpos_compatibility' ), 10 );
 		add_action( 'before_woocommerce_init', array( $this, 'declare_product_editor_compatibility' ), 10 );
 		// Register the block category.
 		add_action( 'block_categories_all', array( $this, 'register_postnl_block_category' ), 10, 2 );
+		add_filter( 'woocommerce_shipping_methods', array( $this, 'add_shipping_method' ) );
 	}
 
 	/**
@@ -162,21 +177,8 @@ class Main {
 	 * Determine which plugin to load.
 	 */
 	public function load_plugin() {
-		// Throw an admin error informing the user this plugin needs WooCommerce to function.
-		add_action( 'admin_notices', array( $this, 'notice_wc_required' ) );
-
-		// Throw an admin error informing the user this plugin needs country settings to be NL and BE.
-		add_action( 'admin_notices', array( $this, 'notice_nl_be_required' ) );
-
-		// Throw an admin error informing the user this plugin needs currency settings to be EUR, USD, GBP, CNY.
-		add_action( 'admin_notices', array( $this, 'notice_currency_required' ) );
-
-		if ( class_exists( 'WooCommerce' ) && Utils::use_available_currency() && Utils::use_available_country() ) {
-			$this->define_constants();
-			$this->init_hooks();
-			$this->checkout_blocks();
-
-		}
+		$this->init_hooks();
+		$this->checkout_blocks();
 	}
 
 	/**
@@ -197,8 +199,6 @@ class Main {
 	public function init_hooks() {
 		add_action( 'init', array( $this, 'init' ), 5 );
 		add_action( 'init', array( $this, 'load_textdomain' ) );
-
-		add_filter( 'woocommerce_shipping_methods', array( $this, 'add_shipping_method' ) );
 
 		// Locate woocommerce template.
 		add_filter( 'woocommerce_locate_template', array( $this, 'woocommerce_locate_template' ), 20, 3 );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Use `plugins_loaded` hook to register/add our shipping method.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Install Flexible Shipping plugin and Polylang
2. Go to WooCommerce >> Settings >> Shipping >> PostNL.
3. Update any fields in the PostNL setting form.
4. The fields will be saved successfully.
5. Try to test the other functionality as well.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.
