### PR TITLE
Add a new contact type 02 with Sender email

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.8.0
+* Add: A new contact type 02 with sender email to the shipping API request.
 
 ### 5.7.3
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+### 5.8.0 (YYYY-MM-DD) =
+* Add: A new contact type 02 with sender email to the shipping API request.
+
 = 5.7.3 (2025-05-06) =
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.
 

--- a/src/Rest_API/Shipping/Client.php
+++ b/src/Rest_API/Shipping/Client.php
@@ -94,6 +94,11 @@ class Client extends Base {
 					'Email'       => $this->item_info->shipment['email'],
 					'SMSNr'       => $this->item_info->shipment['phone'],
 				),
+				array(
+					'ContactType' => '02',
+					'Email'       => $this->item_info->shipper['email'],
+					'SMSNr'       => '',
+				),
 			),
 			'Dimension'           => array(
 				'Weight' => $this->item_info->shipment['total_weight'],

--- a/src/Rest_API/Shipping/Client.php
+++ b/src/Rest_API/Shipping/Client.php
@@ -97,7 +97,6 @@ class Client extends Base {
 				array(
 					'ContactType' => '02',
 					'Email'       => $this->item_info->shipper['email'],
-					'SMSNr'       => '',
 				),
 			),
 			'Dimension'           => array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
[Task link](https://app.clickup.com/t/868cugp99)

### How to test the changes in this Pull Request:

1. Create a new order
2. Generate shipping label
3. check the API request from log you will find 
```php
{
 "ContactType": "02",
 "Email": "sender@email.com",
}
```

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Add - a new contact type 02 with Sender email