### PR TITLE
Fix postalcode required before filling it on the checkout page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,12 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
-### 5.8.1
-* Fix: Postcode required before filling it on the checkout page.
-
 ### 5.8.0
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 * Fix: PHP waring `Function _load_textdomain_just_in_time was called incorrectly`.
+* Fix: Postcode required before filling it on the checkout page.
 
 ### 5.7.3
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.8.1
+* Fix: Postcode required before filling it on the checkout page.
+
 ### 5.8.0
 * Add: A new contact type 02 with sender email to the shipping API request.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+### 5.8.1 (2025-09-06) =
+* Fix: Postcode required before filling it on the checkout page.
+
 ### 5.8.0 (YYYY-MM-DD) =
 * Add: A new contact type 02 with sender email to the shipping API request.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,14 +81,12 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
-### 5.8.1 (2025-09-06) =
-* Fix: Postcode required before filling it on the checkout page.
-
 ### 5.8.0 (2025-xx-xx) =
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 * Fix: PHP waring `Function _load_textdomain_just_in_time was called incorrectly`.
+* Fix: Postcode required before filling it on the checkout page.
 
 = 5.7.3 (2025-05-06) =
 * Tweak: Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -289,10 +289,11 @@ class Container {
 
 			// Validate address.
 			if ( $this->is_address_validation_required() ) {
+				$is_reorder_nl_address_enabled = $this->settings->is_reorder_nl_address_enabled();
 
-				if ( empty( $post_data['shipping_house_number'] ) && $this->settings->is_reorder_nl_address_enabled() ) {
+				if ( empty( $post_data['shipping_house_number'] ) && $is_reorder_nl_address_enabled ) {
 					return;
-				} elseif ( empty( $post_data['shipping_house_number'] ) && ! $this->settings->is_reorder_nl_address_enabled() ) {
+				} elseif ( empty( $post_data['shipping_house_number'] ) && ! $is_reorder_nl_address_enabled ) {
 					throw new \Exception( 'Address does not contain house number!' );
 				}
 

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -283,11 +283,12 @@ class Container {
 
 			$post_data = Address_Utils::set_post_data_address( $post_data );
 
+			if ( empty( $post_data['shipping_postcode'] ) ) {
+				return;
+			}
+
 			// Validate address.
 			if ( $this->is_address_validation_required() ) {
-				if ( empty( $post_data['shipping_postcode'] ) ) {
-					return;
-				}
 
 				if ( empty( $post_data['shipping_house_number'] ) && $this->settings->is_reorder_nl_address_enabled() ) {
 					return;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.Make sure Delivery Days or Pickup points are enabled
2.Make sure the address validation is turned off
3.Select The Netherlands as destination in the checkout
4.select PostNL as shipping method in the checkout
5.Ensure the postcode field is empty (might have to do this in incognito if the fields are saved from earlier instances)
6.The error should now appear at the top of the checkout form



### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
Task
https://app.clickup.com/t/868e80jm7
### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
