### PR TITLE
add dropoffPointsType field and save its value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 * Fix: PHP waring `Function _load_textdomain_just_in_time was called incorrectly`.
 * Fix: Postcode required before filling it on the checkout page.
+* Fix: Drop-off point type not saving when orders are created via Blocks checkout.
 
 ### 5.7.3
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 ### 5.8.0 (YYYY-MM-DD) =
 * Add: A new contact type 02 with sender email to the shipping API request.
+* Fix: Drop-off point type not saving when orders are created via Blocks checkout.
 
 = 5.7.3 (2025-05-06) =
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 * Fix: PHP waring `Function _load_textdomain_just_in_time was called incorrectly`.
 * Fix: Postcode required before filling it on the checkout page.
+* Fix: Drop-off point type not saving when orders are created via Blocks checkout.
 
 = 5.7.3 (2025-05-06) =
 * Tweak: Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/src/Checkout_Blocks/Extend_Store_Endpoint.php
+++ b/src/Checkout_Blocks/Extend_Store_Endpoint.php
@@ -246,6 +246,16 @@ class Extend_Store_Endpoint {
 				'default'     => '',
 				'type'        => 'string',
 			),
+			'dropoffPointsType'           => array(
+				'description' => 'Type of the drop-off point selection',
+				'context'     => array(
+					'view',
+					'edit'
+				),
+				'readonly'    => false,
+				'default'     => '',
+				'type'        => 'string',
+			),
 			'dropoffPointsDistance'       => array(
 				'description' => 'Distance to the drop-off point',
 				'context'     => array(

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -251,6 +251,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			sessionStorage.removeItem( 'postnl_dropoffPointsPartnerID' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsDate' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsTime' );
+			sessionStorage.removeItem( 'postnl_dropoffPointsType' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsDistance' );
 		}
 	}, [ isComplete, letterbox, showContainer ] );
@@ -299,6 +300,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 		setExtensionData( 'postnl', 'dropoffPointsPartnerID', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDate', '' );
 		setExtensionData( 'postnl', 'dropoffPointsTime', '' );
+		setExtensionData( 'postnl', 'dropoffPointsType', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDistance', '' );
 
 	}, [ letterbox, showContainer, deliveryOptions, setExtensionData ] );

--- a/src/Checkout_Blocks/js/postnl-delivery-day/block.js
+++ b/src/Checkout_Blocks/js/postnl-delivery-day/block.js
@@ -187,6 +187,7 @@ export const Block = ( {
 		sessionStorage.removeItem( 'postnl_dropoffPointsPartnerID' );
 		sessionStorage.removeItem( 'postnl_dropoffPointsDate' );
 		sessionStorage.removeItem( 'postnl_dropoffPointsTime' );
+		sessionStorage.removeItem( 'postnl_dropoffPointsType' );
 		sessionStorage.removeItem( 'postnl_dropoffPointsDistance' );
 
 		setExtensionData( 'postnl', 'dropoffPoints', '' );
@@ -199,6 +200,7 @@ export const Block = ( {
 		setExtensionData( 'postnl', 'dropoffPointsPartnerID', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDate', '' );
 		setExtensionData( 'postnl', 'dropoffPointsTime', '' );
+		setExtensionData( 'postnl', 'dropoffPointsType', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDistance', null );
 
 		try {

--- a/src/Checkout_Blocks/js/postnl-dropoff-points/block.js
+++ b/src/Checkout_Blocks/js/postnl-dropoff-points/block.js
@@ -92,6 +92,14 @@ export const Block = ( {
 		}
 	);
 
+	const [ dropoffPointsType, setDropoffPointsType ] = useState(
+		() => {
+			return (
+				sessionStorage.getItem( 'postnl_dropoffPointsType' ) || ''
+			);
+		}
+	);
+
 	// Debounce setting extension data to optimize performance
 	const debouncedSetExtensionData = useCallback(
 		debounce( ( namespace, key, value ) => {
@@ -185,6 +193,14 @@ export const Block = ( {
 		);
 	}, [ dropoffPointsDistance, debouncedSetExtensionData ] );
 
+	useEffect( () => {
+		debouncedSetExtensionData(
+			'postnl',
+			'dropoffPointsType',
+			dropoffPointsType
+		);
+	}, [ dropoffPointsType, debouncedSetExtensionData ] );
+
 	/**
 	 * Effect to handle tab activation
 	 */
@@ -212,6 +228,7 @@ export const Block = ( {
 		setDropoffPointsPartnerID( '' );
 		setDropoffPointsDate( '' );
 		setDropoffPointsTime( '' );
+		setDropoffPointsType( '' );
 		setDropoffPointsDistance( null );
 		if ( clearSession ) {
 			sessionStorage.removeItem( 'postnl_dropoffPointsAddressCompany' );
@@ -223,6 +240,7 @@ export const Block = ( {
 			sessionStorage.removeItem( 'postnl_dropoffPointsPartnerID' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsDate' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsTime' );
+			sessionStorage.removeItem( 'postnl_dropoffPointsType' );
 			sessionStorage.removeItem( 'postnl_dropoffPointsDistance' );
 		}
 		setExtensionData( 'postnl', 'dropoffPoints', '' );
@@ -235,6 +253,7 @@ export const Block = ( {
 		setExtensionData( 'postnl', 'dropoffPointsPartnerID', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDate', '' );
 		setExtensionData( 'postnl', 'dropoffPointsTime', '' );
+		setExtensionData( 'postnl', 'dropoffPointsType', '' );
 		setExtensionData( 'postnl', 'dropoffPointsDistance', null );
 	};
 
@@ -355,6 +374,12 @@ export const Block = ( {
 			dropoffPoint.time || ''
 		);
 
+		setDropoffPointsType( dropoffPoint.type || '' );
+		sessionStorage.setItem(
+			'postnl_dropoffPointsType',
+			dropoffPoint.type || ''
+		);
+
 		setDropoffPointsDistance( Number( dropoffPoint.distance ) || null );
 		sessionStorage.setItem(
 			'postnl_dropoffPointsDistance',
@@ -405,6 +430,11 @@ export const Block = ( {
 		);
 		setExtensionData(
 			'postnl',
+			'dropoffPointsType',
+			dropoffPoint.type || ''
+		);
+		setExtensionData(
+			'postnl',
 			'dropoffPointsDistance',
 			Number( dropoffPoint.distance ) || null
 		);
@@ -447,6 +477,7 @@ export const Block = ( {
 									data-loc_code={ point.loc_code }
 									data-date={ point.date }
 									data-time={ point.time }
+									data-type={ point.type }
 									data-distance={ point.distance }
 									data-address_company={
 										point.address.company
@@ -555,6 +586,12 @@ export const Block = ( {
 				name="dropoffPointsTime"
 				id="dropoffPointsTime"
 				value={ dropoffPointsTime }
+			/>
+			<input
+				type="hidden"
+				name="dropoffPointsType"
+				id="dropoffPointsType"
+				value={ dropoffPointsType }
 			/>
 			<input
 				type="hidden"


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
add dropoffPointsType field to the dropoffPoints block and save its value
[Task link](https://app.clickup.com/t/868e7hp4k)
### How to test the changes in this Pull Request:

1. Add a new product to the cart and go to blocks checkout page 
2. Select drop off point and inspect to check that the hidden field for dropoffPointsType is exist and has value
3. Create an order then check the Rest API /wp-json/wc/v2/orders and search for "dropoff_points_type" it should has value

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fixed: Drop-off point type not saving when orders are created via Blocks checkout