### PR TITLE
Declare WooCommerce feature support early to avoid false incompatibility warning

### DIFF
--- a/src/Main.php
+++ b/src/Main.php
@@ -101,19 +101,25 @@ class Main {
 		// Throw an admin error informing the user this plugin needs WooCommerce to function.
 		add_action( 'admin_notices', array( $this, 'notice_wc_required' ) );
 
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
+		// Declare WooCommerce features compatibility.
+		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_hpos_compatibility' ) );
+		add_action( 'before_woocommerce_init', array( $this, 'declare_product_editor_compatibility' ) );
+
 		// Throw an admin error informing the user this plugin needs country settings to be NL and BE.
 		add_action( 'admin_notices', array( $this, 'notice_nl_be_required' ) );
 
 		// Throw an admin error informing the user this plugin needs currency settings to be EUR, USD, GBP, CNY.
 		add_action( 'admin_notices', array( $this, 'notice_currency_required' ) );
 
-		if ( ! class_exists( 'WooCommerce' ) || ! Utils::use_available_currency() || ! Utils::use_available_country() ) {
+		if ( ! Utils::use_available_currency() || ! Utils::use_available_country() ) {
 			return;
 		}
 
 		add_action( 'init', array( $this, 'load_plugin' ), 1 );
-		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_hpos_compatibility' ), 10 );
-		add_action( 'before_woocommerce_init', array( $this, 'declare_product_editor_compatibility' ), 10 );
 		// Register the block category.
 		add_action( 'block_categories_all', array( $this, 'register_postnl_block_category' ), 10, 2 );
 		add_filter( 'woocommerce_shipping_methods', array( $this, 'add_shipping_method' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Reordered the code responsible for declaring WooCommerce feature compatibility to ensure it runs before conditional checks for supported countries or currencies.
Previously, the feature declarations (e.g., HPOS, product editor support) were added after the plugin validated if the current store is based in NL or BE. This caused WooCommerce to mark the plugin as incompatible with some features when installed on stores outside of those countries.

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/3c90a1dd-0ad1-4ad4-9398-1e1ad99d9382" />

### How to test the changes in this Pull Request:

1. Install the plugin on a WooCommerce store not based in NL or BE.
2. Enable HPOS and block-based product editor from WooCommerce > Settings > Advanced > Features.
3. Check that no compatibility warning appears on the WooCommerce plugins page.
4. Confirm that admin notices for unsupported currency or country still appear when appropriate.
5. Confirm plugin still loads as expected in valid setups (NL or BE + supported currency).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
