### PR TITLE
Fix insured shipping product mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 ### 5.8.0
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
+* Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 
 ### 5.7.3
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 ### 5.8.0 (2025-xx-xx) =
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
+* Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
 
 = 5.7.3 (2025-05-06) =
 * Tweak: Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/src/Helper/Mapping.php
+++ b/src/Helper/Mapping.php
@@ -192,6 +192,41 @@ class Mapping {
 							'options'     => array(),
 						),
 						array(
+							'combination' => array( 'insured_shipping', 'track_and_trace' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'signature_on_delivery' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'only_home_address' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'signature_on_delivery', 'only_home_address' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'track_and_trace', 'signature_on_delivery' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'track_and_trace', 'only_home_address' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
+							'combination' => array( 'insured_shipping', 'track_and_trace', 'signature_on_delivery', 'only_home_address' ),
+							'code'        => '4914',
+							'options'     => array(),
+						),
+						array(
 							'combination' => array( 'mailboxpacket' ),
 							'code'        => '6440',
 							'options'     => array(),


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Task [link](https://app.clickup.com/t/868ey6pg7)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
Map all combinations that include insured_shipping but do not include packet to product code 4914.

1. Insured
2. Insured + Track & Trace
3. Insured + Signature on Delivery
4. Insured + Only Home Address
5. Insured + Signature on Delivery + Only Home Address
6. Insured + Track & Trace + Signature on Delivery
7. Insured + Track & Trace + Only Home Address
8. Insured + Track & Trace + Only Home Address + Signature on Delivery

### How to test the changes in this Pull Request:

1. Set store country to be Netherlands
2. Create a new order with Belgium address
3. From L&T select one of the above combination then create label
4. Check the log to make sure the API request has product code 4914

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
