### PR TITLE
Make it possible to decide which tab to show first in the delivery options menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
+* Add: Setting to choose default checkout tab (Home Delivery or Pickup Points).
 
 ### 5.7.3
 * Tweak : Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/assets/js/fe-checkout.js
+++ b/assets/js/fe-checkout.js
@@ -52,6 +52,18 @@
 
 				pri_container.find( '.postnl_checkout_content_container .postnl_content' ).removeClass( 'active' );
 				pri_container.find( '#postnl_' + current_val + '_content' ).addClass( 'active' );
+
+				// Auto-select first option in the newly active tab if no option is currently selected
+				var active_content = pri_container.find( '#postnl_' + current_val + '_content' );
+				var field_name = 'postnl_' + current_val;
+				var current_selection = jQuery( 'input[name=' + field_name + ']:checked' );
+
+				if ( current_selection.length === 0 ) {
+					var first_option = active_content.find( 'input[name=' + field_name + ']:first' );
+					if ( first_option.length > 0 ) {
+						first_option.prop( 'checked', true ).trigger( 'change' );
+					}
+				}
 			} );
 
 			radio_options.on( 'change', function() {
@@ -70,7 +82,11 @@
 				jQuery('body').trigger('update_checkout');
 			} );
 
-			checkout_option.find( '.postnl_checkout_tab_list .active .postnl_option' ).trigger( 'click' );
+			// Trigger the active tab to ensure proper initialization
+			var active_tab_input = checkout_option.find( '.postnl_checkout_tab_list .active .postnl_option' );
+			if ( active_tab_input.length > 0 ) {
+				active_tab_input.trigger( 'change' );
+			}
 		},
 	};
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 * Add: Ability for marking products as 18+ and automatically apply ID Check to orders containing them.
 * Add: A new contact type 02 with sender email to the shipping API request.
 * Fix: Ressolve issue where insured NL>BE shipments defaulted to standard shipment instead of insured shipment.
+* Add: Setting to choose default checkout tab (Home Delivery or Pickup Points).
 
 = 5.7.3 (2025-05-06) =
 * Tweak: Use `plugins_loaded` hook to add the shipping method for Flexible shipping and Polylang plugins compatibility.

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -204,6 +204,7 @@ class Blocks_Integration implements IntegrationInterface {
 			'letterbox'                => $letterbox,
 			'is_nl_address_enabled'    => $settings->is_reorder_nl_address_enabled(),
 			'is_pickup_points_enabled' => $settings->is_pickup_points_enabled(),
+			'default_checkout_tab'     => $settings->get_default_checkout_tab(),
 		);
 	}
 }

--- a/src/Checkout_Blocks/js/postnl-container/block.js
+++ b/src/Checkout_Blocks/js/postnl-container/block.js
@@ -30,7 +30,30 @@ export const Block = ( { checkoutExtensionData } ) => {
 			name: __( 'Dropoff Points', 'postnl-for-woocommerce' ),
 		});
 	}
-	const [ activeTab, setActiveTab ] = useState( tabs[ 0 ].id );
+
+	// Determine default tab based on settings and available tabs
+	const getDefaultTab = () => {
+		const defaultTabSetting = postnlData.default_checkout_tab || 'delivery_day';
+
+		// Check if the preferred tab is available
+		const preferredTab = tabs.find( tab => tab.id === defaultTabSetting );
+		if ( preferredTab ) {
+			return defaultTabSetting;
+		}
+
+		// Fallback to first available tab
+		return tabs.length > 0 ? tabs[ 0 ].id : 'delivery_day';
+	};
+
+	const [ activeTab, setActiveTab ] = useState( getDefaultTab() );
+
+	// Update active tab when tabs change (e.g., pickup points become available/unavailable)
+	useEffect( () => {
+		const currentDefaultTab = getDefaultTab();
+		if ( activeTab !== currentDefaultTab && tabs.find( tab => tab.id === currentDefaultTab ) ) {
+			setActiveTab( currentDefaultTab );
+		}
+	}, [ tabs.length, postnlData.is_pickup_points_enabled ] );
 
 	const letterbox = postnlData.letterbox || false;
 	const { CART_STORE_KEY, CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;

--- a/src/Checkout_Blocks/js/postnl-dropoff-points/block.js
+++ b/src/Checkout_Blocks/js/postnl-dropoff-points/block.js
@@ -191,8 +191,16 @@ export const Block = ( {
 	useEffect( () => {
 		if ( ! isActive ) {
 			clearSelections();
+			return;
 		}
-	}, [ isActive ] );
+
+		// If active and no option selected, select the first option if available
+		if ( isActive && ! dropoffPoints && Array.isArray( dropoffOptions ) && dropoffOptions.length > 0 ) {
+			const firstPoint = dropoffOptions[ 0 ];
+			const firstValue = `${ firstPoint.partner_id }-${ firstPoint.loc_code }`;
+			handleOptionChange( firstValue );
+		}
+	}, [ isActive, dropoffOptions ] );
 
 	/**
 	 * Helper function to clear selections

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -105,6 +105,31 @@ class Container {
 	}
 
 	/**
+	 * Get default tab based on settings and available tabs.
+	 *
+	 * @param array $tabs Available tabs.
+	 *
+	 * @return String
+	 */
+	public function get_default_tab( array $tabs ): string {
+		if ( empty( $tabs ) ) {
+			return '';
+		}
+
+		$default_tab_setting = $this->settings->get_default_checkout_tab();
+
+		// Check if the preferred tab is available.
+		foreach ( $tabs as $tab ) {
+			if ( $tab['id'] === $default_tab_setting ) {
+				return $default_tab_setting;
+			}
+		}
+
+		// Fallback to first available tab.
+		return $tabs[0]['id'];
+	}
+
+	/**
 	 * Get checkout $_POST['post_data'].
 	 *
 	 * @return array
@@ -229,12 +254,15 @@ class Container {
 			return;
 		}
 
+		$available_tabs = $this->get_available_tabs( $checkout_data['response'] );
+
 		$template_args = array(
-			'tabs'        => $this->get_available_tabs( $checkout_data['response'] ),
+			'tabs'        => $available_tabs,
 			'response'    => $checkout_data['response'],
 			'post_data'   => $checkout_data['post_data'],
 			'default_val' => $this->get_default_value( $checkout_data['response'], $checkout_data['post_data'] ),
 			'letterbox'   => $checkout_data['letterbox'],
+			'default_tab' => $this->get_default_tab( $available_tabs ),
 			'fields'      => array(
 				array(
 					'name'  => $this->tab_field,

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -292,6 +292,19 @@ class Settings extends \WC_Settings_API {
 				'for_country' => array( 'NL', 'BE' ),
 				'class'       => 'country-nl country-be',
 			),
+			'default_checkout_tab'            => array(
+				'title'       => __( 'Default Checkout Tab', 'postnl-for-woocommerce' ),
+				'type'        => 'select',
+				'description' => __( 'Choose which delivery option tab to show first by default in the checkout.', 'postnl-for-woocommerce' ),
+				'desc_tip'    => true,
+				'default'     => 'delivery_day',
+				'options'     => array(
+					'delivery_day'   => __( 'Home Delivery', 'postnl-for-woocommerce' ),
+					'dropoff_points' => __( 'Pickup Points', 'postnl-for-woocommerce' ),
+				),
+				'for_country' => array( 'NL', 'BE' ),
+				'class'       => 'country-nl country-be',
+			),
 
 			/*
 			Temporarily commented out.
@@ -1026,6 +1039,15 @@ class Settings extends \WC_Settings_API {
 	 */
 	public function is_pickup_points_enabled() {
 		return ( 'yes' === $this->get_enable_pickup_points() );
+	}
+
+	/**
+	 * Get default checkout tab from the settings.
+	 *
+	 * @return String
+	 */
+	public function get_default_checkout_tab() {
+		return $this->get_country_option( 'default_checkout_tab', 'delivery_day' );
 	}
 
 	/**

--- a/templates/checkout/postnl-container.php
+++ b/templates/checkout/postnl-container.php
@@ -25,7 +25,7 @@ $field = array_shift( $fields );
 				<ul class="postnl_checkout_tab_list">
 					<?php foreach ( $tabs as $index => $field_tab ) { ?>
 						<?php
-							$is_checked      = ( $field['value'] === $field_tab['id'] ) || ( empty( $field['value'] ) && 0 === $index );
+							$is_checked      = ( $field['value'] === $field_tab['id'] ) || ( empty( $field['value'] ) && $field_tab['id'] === $default_tab );
 							$active_class    = ( $is_checked ) ? 'active' : '';
 							$display_checked = ( $is_checked ) ? 'checked="checked"' : '';
 						?>

--- a/templates/checkout/postnl-dropoff-points.php
+++ b/templates/checkout/postnl-dropoff-points.php
@@ -109,13 +109,13 @@ function postnl_display_dropoff_desc( $data ) {
 <div class="postnl_content" id="postnl_dropoff_points_content">
 	<?php postnl_display_dropoff_desc( $data ); ?>
 	<ul class="postnl_dropoff_points_list postnl_list">
-		<?php foreach ( $data['dropoff_options'] as $point ) { ?>
+		<?php foreach ( $data['dropoff_options'] as $index => $point ) { ?>
 			<?php
 			$value    = sanitize_title( $point['partner_id'] . '-' . $point['loc_code'] );
 			$radio_id = sanitize_title( $point['partner_id'] . '-' . $point['loc_code'] );
 
 			$address    = implode( ' ', array_values( postnl_generate_pickup_address( $point['address'] ) ) );
-			$is_checked = ( $value === $data['value'] ) ? 'checked="checked"' : '';
+			$is_checked = ( $value === $data['value'] || ( empty( $data['value'] ) && 0 === $index ) ) ? 'checked="checked"' : '';
 
 			$point_key = $point;
 			?>


### PR DESCRIPTION
…ons menu

### All Submissions:

* [ ] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
