### PR TITLE
add full fees to the tabs titles

### DIFF
--- a/assets/js/fe-checkout.js
+++ b/assets/js/fe-checkout.js
@@ -43,9 +43,10 @@
 		let text = postnlParams.i18n.deliveryDays;
 		const fees = [];
 
-		// Add base fee if > 0
-		if ( tabBase > 0 && postnlParams.delivery_day_fee_formatted ) {
-			fees.push( postnlParams.delivery_day_fee_formatted );
+		// Add base+additional total if > 0
+		const deliveryTotalFormatted = $label.data( 'total-formatted' ) || '';
+		if ( tabBase > 0 && deliveryTotalFormatted ) {
+			fees.push( deliveryTotalFormatted );
 		}
 
 		if ( extraFee > 0 && extraFeeFormatted ) {
@@ -75,9 +76,10 @@
 
 		let text = postnlParams.i18n.pickup;
 
-		// Add base fee if > 0.
-		if ( tabBase > 0 && postnlParams.pickup_fee_formatted ) {
-			text += ' (+' + postnlParams.pickup_fee_formatted + ')';
+		// Add base+additional total if > 0.
+		const pickupTotalFormatted = $label.data( 'total-formatted' ) || '';
+		if ( tabBase > 0 && pickupTotalFormatted ) {
+			text += ' (+' + pickupTotalFormatted + ')';
 		}
 
 		$label.children( 'span' ).first().text( text );

--- a/assets/js/fe-checkout.js
+++ b/assets/js/fe-checkout.js
@@ -23,38 +23,12 @@
 		}
 
 		const tabBase = parseFloat( $label.data( 'base-fee' ) || 0 );
-		let extraFee = 0;
-		let extraFeeFormatted = '';
-
-		if ( $input.is( ':checked' ) ) {
-			extraFee = parseFloat(
-				$( '#postnl_delivery_day_price' ).val() || 0
-			);
-			if ( isNaN( extraFee ) ) {
-				extraFee = 0;
-			}
-			// Get formatted price from selected delivery option
-			const $selected = $( '.postnl_sub_radio:checked' ).closest( 'li' );
-			if ( $selected.length ) {
-				extraFeeFormatted = $selected.data( 'price-formatted' ) || '';
-			}
-		}
-
 		let text = postnlParams.i18n.deliveryDays;
-		const fees = [];
 
-		// Add base+additional total if > 0
+		// Show full total (carrier + tab fee).
 		const deliveryTotalFormatted = $label.data( 'total-formatted' ) || '';
 		if ( tabBase > 0 && deliveryTotalFormatted ) {
-			fees.push( deliveryTotalFormatted );
-		}
-
-		if ( extraFee > 0 && extraFeeFormatted ) {
-			fees.push( extraFeeFormatted );
-		}
-
-		if ( fees.length > 0 ) {
-			text += ' (+' + fees.join( ' +' ) + ')';
+			text += ' (' + deliveryTotalFormatted + ')';
 		}
 
 		$label.children( 'span' ).first().text( text );
@@ -76,10 +50,10 @@
 
 		let text = postnlParams.i18n.pickup;
 
-		// Add base+additional total if > 0.
+		// Show full total (carrier + tab fee).
 		const pickupTotalFormatted = $label.data( 'total-formatted' ) || '';
 		if ( tabBase > 0 && pickupTotalFormatted ) {
-			text += ' (+' + pickupTotalFormatted + ')';
+			text += ' (' + pickupTotalFormatted + ')';
 		}
 
 		$label.children( 'span' ).first().text( text );

--- a/assets/js/fe-checkout.js
+++ b/assets/js/fe-checkout.js
@@ -23,11 +23,12 @@
 		}
 
 		const tabBase = parseFloat( $label.data( 'base-fee' ) || 0 );
+		const totalNumeric = parseFloat( $label.data( 'total-numeric' ) || tabBase );
 		let text = postnlParams.i18n.deliveryDays;
 
 		// Show full total (carrier + tab fee).
 		const deliveryTotalFormatted = $label.data( 'total-formatted' ) || '';
-		if ( tabBase > 0 && deliveryTotalFormatted ) {
+		if ( totalNumeric > 0 && deliveryTotalFormatted ) {
 			text += ' (' + deliveryTotalFormatted + ')';
 		}
 
@@ -47,12 +48,13 @@
 		}
 
 		const tabBase = parseFloat( $label.data( 'base-fee' ) || 0 );
+		const totalNumeric = parseFloat( $label.data( 'total-numeric' ) || tabBase );
 
 		let text = postnlParams.i18n.pickup;
 
 		// Show full total (carrier + tab fee).
 		const pickupTotalFormatted = $label.data( 'total-formatted' ) || '';
-		if ( tabBase > 0 && pickupTotalFormatted ) {
+		if ( totalNumeric > 0 && pickupTotalFormatted ) {
 			text += ' (' + pickupTotalFormatted + ')';
 		}
 

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -167,7 +167,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 						? __( 'Delivery', 'postnl-for-woocommerce' )
 						: __( 'Pickup', 'postnl-for-woocommerce' );
 
-				if ( tab.base > 0 && selectedShippingFee > 0 && carrierBaseCost > 0 ) {
+				if ( tab.base > 0 && selectedShippingFee > 0 ) {
 					const tabTotal = carrierBaseCost + tab.base;
 
 					if ( tabTotal > tab.base ) {
@@ -204,6 +204,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			} ),
 		[
 			baseTabs,
+			activeTab,
 			extraDeliveryFee,
 			extraDeliveryFeeFormatted,
 			carrierBaseCost,
@@ -240,12 +241,12 @@ export const Block = ( { checkoutExtensionData } ) => {
 	}, [] );
 
 	// When free shipping is active, clear any previously applied backend delivery fee.
-	useEffect( () => {
-		if ( selectedShippingFee === 0 ) {
-			setFeeState( { extraDeliveryFee: 0, extraDeliveryFeeFormatted: '' } );
-			clearBackendDeliveryFee();
-		}
-	}, [ selectedShippingFee ] );
+	// useEffect( () => {
+	// 	if ( selectedShippingFee === 0 ) {
+	// 		setFeeState( { extraDeliveryFee: 0, extraDeliveryFeeFormatted: '' } );
+	// 		clearBackendDeliveryFee();
+	// 	}
+	// }, [ selectedShippingFee ] );
 
 	// To prevent infinite loops if we update the address programmatically
 	const isUpdatingAddress = useRef( false );

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -167,7 +167,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 						? __( 'Delivery', 'postnl-for-woocommerce' )
 						: __( 'Pickup', 'postnl-for-woocommerce' );
 
-				if ( tab.base > 0 ) {
+				if ( tab.base > 0 && selectedShippingFee > 0 && carrierBaseCost > 0 ) {
 					const tabTotal = carrierBaseCost + tab.base;
 
 					if ( tabTotal > tab.base ) {
@@ -208,6 +208,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			extraDeliveryFeeFormatted,
 			carrierBaseCost,
 			currency,
+			selectedShippingFee,
 		]
 	);
 
@@ -237,6 +238,14 @@ export const Block = ( { checkoutExtensionData } ) => {
 			extraDeliveryFeeFormatted: priceData.formatted || '',
 		} );
 	}, [] );
+
+	// When free shipping is active, clear any previously applied backend delivery fee.
+	useEffect( () => {
+		if ( selectedShippingFee === 0 ) {
+			setFeeState( { extraDeliveryFee: 0, extraDeliveryFeeFormatted: '' } );
+			clearBackendDeliveryFee();
+		}
+	}, [ selectedShippingFee ] );
 
 	// To prevent infinite loops if we update the address programmatically
 	const isUpdatingAddress = useRef( false );

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -168,8 +168,37 @@ export const Block = ( { checkoutExtensionData } ) => {
 		return Number( saved.price || 0 );
 	} );
 
+	// Tracks the extra fee AND active tab the server has confirmed (both baked
+	// into selectedShippingFee). Only sync when selectedShippingFee changes so
+	// carrierBase stays stable while any cart update is in-flight.
+	const pendingExtraFeeRef = useRef( Number( getDeliveryDay().price || 0 ) );
+	const pendingActiveTabRef = useRef( baseTabs[ 0 ].id );
+	const [ confirmedExtraFee, setConfirmedExtraFee ] = useState(
+		() => Number( getDeliveryDay().price || 0 )
+	);
+	const [ confirmedActiveTab, setConfirmedActiveTab ] = useState(
+		() => baseTabs[ 0 ].id
+	);
+
+	// When the cart store updates (server round-trip complete), lock in both
+	// the pending extra fee and the pending active tab so all tab titles
+	// recalculate together with the newly confirmed selectedShippingFee.
+	useEffect( () => {
+		if ( cartDataLoaded ) {
+			setConfirmedExtraFee( pendingExtraFeeRef.current );
+			setConfirmedActiveTab( pendingActiveTabRef.current );
+		}
+	}, [ selectedShippingFee, cartDataLoaded ] );
+
+	const handleTabChange = useCallback( ( tabId ) => {
+		pendingActiveTabRef.current = tabId;
+		setActiveTab( tabId );
+	}, [] );
+
 	const handlePriceChange = useCallback( ( priceData ) => {
-		setExtraDeliveryFee( priceData.numeric || 0 );
+		const newFee = priceData.numeric || 0;
+		pendingExtraFeeRef.current = newFee;
+		setExtraDeliveryFee( newFee );
 	}, [] );
 
 	const tabs = useMemo( () => {
@@ -185,14 +214,16 @@ export const Block = ( { checkoutExtensionData } ) => {
 			} ) );
 		}
 
-		const activeTabBase = isSupportedMethod
-			? baseTabs.find( ( t ) => t.id === activeTab )?.base || 0
+		// Use confirmedActiveTab + confirmedExtraFee (both server-confirmed) so
+		// carrierBase stays stable while any cart update is in-flight.
+		const confirmedTabBase = isSupportedMethod
+			? baseTabs.find( ( t ) => t.id === confirmedActiveTab )?.base || 0
 			: 0;
-		const activeExtra = isSupportedMethod
-			? activeTabBase +
-			( activeTab === 'delivery_day' ? extraDeliveryFee : 0 )
+		const confirmedActiveExtra = isSupportedMethod
+			? confirmedTabBase +
+			( confirmedActiveTab === 'delivery_day' ? confirmedExtraFee : 0 )
 			: 0;
-		const carrierBase = Math.max( 0, selectedShippingFee - activeExtra );
+		const carrierBase = Math.max( 0, selectedShippingFee - confirmedActiveExtra );
 		const minorUnit = currency.minorUnit ?? 2;
 		const multiplier = Math.pow( 10, minorUnit );
 
@@ -221,11 +252,12 @@ export const Block = ( { checkoutExtensionData } ) => {
 		} );
 	}, [
 		baseTabs,
-		activeTab,
+		confirmedActiveTab,
 		selectedShippingFee,
 		isSupportedMethod,
 		currency,
 		extraDeliveryFee,
+		confirmedExtraFee,
 		cartDataLoaded,
 	] );
 
@@ -534,7 +566,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 											value={ tab.id }
 											checked={ activeTab === tab.id }
 											onChange={ () =>
-												setActiveTab( tab.id )
+												handleTabChange( tab.id )
 											}
 										/>
 									</label>

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -63,12 +63,21 @@ export const Block = ( { checkoutExtensionData } ) => {
 	const letterbox = postnlData.letterbox || false;
 	const { CART_STORE_KEY, CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
 
-	const { selectedShippingFee, selectedMethodId } = useSelect(
+	const { selectedShippingFee, selectedMethodId, cartDataLoaded } = useSelect(
 		( select ) => {
 			const store = select( CART_STORE_KEY );
 			if ( ! store || ! store.getCartData ) {
-				return { selectedShippingFee: 0, selectedMethodId: '' };
+				return {
+					selectedShippingFee: 0,
+					selectedMethodId: '',
+					cartDataLoaded: false,
+				};
 			}
+
+			const hasLoaded =
+				typeof store.hasFinishedResolution === 'function'
+					? store.hasFinishedResolution( 'getCartData', [] )
+					: true;
 
 			const packages = store.getCartData().shippingRates || [];
 			const taxDisplayIncl = postnlData.tax_display_incl || false;
@@ -88,6 +97,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 							selectedShippingFee:
 								displayPrice / Math.pow( 10, minor ),
 							selectedMethodId: chosen.method_id || '',
+							cartDataLoaded: hasLoaded,
 						};
 					}
 				}
@@ -99,11 +109,16 @@ export const Block = ( { checkoutExtensionData } ) => {
 					return {
 						selectedShippingFee: Number( totals.shipping_total ),
 						selectedMethodId: '',
+						cartDataLoaded: hasLoaded,
 					};
 				}
 			}
 
-			return { selectedShippingFee: 0, selectedMethodId: '' };
+			return {
+				selectedShippingFee: 0,
+				selectedMethodId: '',
+				cartDataLoaded: hasLoaded,
+			};
 		},
 		[ CART_STORE_KEY ]
 	);
@@ -146,7 +161,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 
 	const [ activeTab, setActiveTab ] = useState( baseTabs[ 0 ].id );
 
-	const isFreeShipping = selectedShippingFee === 0;
+	const isFreeShipping = cartDataLoaded && selectedShippingFee === 0;
 
 	const tabs = useMemo( () => {
 		const activeTabBase = isSupportedMethod

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -63,11 +63,11 @@ export const Block = ( { checkoutExtensionData } ) => {
 	const letterbox = postnlData.letterbox || false;
 	const { CART_STORE_KEY, CHECKOUT_STORE_KEY } = window.wc.wcBlocksData;
 
-	const selectedShippingFee = useSelect(
+	const { selectedShippingFee, selectedMethodId } = useSelect(
 		( select ) => {
 			const store = select( CART_STORE_KEY );
 			if ( ! store || ! store.getCartData ) {
-				return 0;
+				return { selectedShippingFee: 0, selectedMethodId: '' };
 			}
 
 			const packages = store.getCartData().shippingRates || [];
@@ -79,7 +79,10 @@ export const Block = ( { checkoutExtensionData } ) => {
 					const minor = Number( chosen.currency_minor_unit || 0 );
 					const price = parseFloat( chosen.price );
 					if ( ! Number.isNaN( price ) ) {
-						return price / Math.pow( 10, minor );
+						return {
+							selectedShippingFee: price / Math.pow( 10, minor ),
+							selectedMethodId: chosen.method_id || '',
+						};
 					}
 				}
 			}
@@ -87,14 +90,21 @@ export const Block = ( { checkoutExtensionData } ) => {
 			if ( store.getCartTotals ) {
 				const totals = store.getCartTotals();
 				if ( totals && totals.shipping_total ) {
-					return Number( totals.shipping_total );
+					return {
+						selectedShippingFee: Number( totals.shipping_total ),
+						selectedMethodId: '',
+					};
 				}
 			}
 
-			return 0;
+			return { selectedShippingFee: 0, selectedMethodId: '' };
 		},
 		[ CART_STORE_KEY ]
 	);
+
+	// True when the selected method is one that has PostNL tab fees baked in.
+	const supportedMethods = postnlData.supported_shipping_methods || [ 'postnl' ];
+	const isSupportedMethod = supportedMethods.includes( selectedMethodId );
 
 	const [ { extraDeliveryFee, extraDeliveryFeeFormatted }, setFeeState ] =
 		useState( () => {
@@ -139,81 +149,47 @@ export const Block = ( { checkoutExtensionData } ) => {
 
 	const [ activeTab, setActiveTab ] = useState( baseTabs[ 0 ].id );
 
-	const [ carrierBaseCost, setCarrierBaseCost ] = useState(
-		() => selectedShippingFee - baseTabs[ 0 ].base - extraDeliveryFee
-	);
+	const isFreeShipping = selectedShippingFee === 0;
 
-	const prevShipping = useRef( selectedShippingFee );
+	const tabs = useMemo( () => {
+		const activeTabBase = isSupportedMethod
+			? baseTabs.find( ( t ) => t.id === activeTab )?.base || 0
+			: 0;
+		const carrierBase = Math.max( 0, selectedShippingFee - activeTabBase );
 
-	useEffect( () => {
-		if ( prevShipping.current === selectedShippingFee ) {
-			return;
-		}
-		prevShipping.current = selectedShippingFee;
+		return baseTabs.map( ( tab ) => {
+			let title =
+				tab.id === 'delivery_day'
+					? __( 'Delivery', 'postnl-for-woocommerce' )
+					: __( 'Pickup', 'postnl-for-woocommerce' );
 
-		const currentTabBase =
-			baseTabs.find( ( tab ) => tab.id === activeTab )?.base || 0;
-		const extra = activeTab === 'delivery_day' ? extraDeliveryFee : 0;
+			if ( tab.base > 0 && selectedShippingFee > 0 ) {
+				const tabTotal = carrierBase + tab.base;
 
-		const raw = selectedShippingFee - currentTabBase - extra;
-		setCarrierBaseCost( raw < 0 ? 0 : raw );
-	}, [ selectedShippingFee ] );
-
-	const tabs = useMemo(
-		() =>
-			baseTabs.map( ( tab ) => {
-				let title =
-					tab.id === 'delivery_day'
-						? __( 'Delivery', 'postnl-for-woocommerce' )
-						: __( 'Pickup', 'postnl-for-woocommerce' );
-
-				if ( tab.base > 0 && selectedShippingFee > 0 ) {
-					const tabTotal = carrierBaseCost + tab.base;
-
-					if ( tabTotal > tab.base ) {
-						// carrierBaseCost is known: show the full shipping total
-						const minorUnit = currency.minorUnit ?? 2;
-						const totalFormatted = formatPrice(
-							Math.round( tabTotal * Math.pow( 10, minorUnit ) ),
-							currency
-						);
-						title += ` (${ totalFormatted }`;
-						if (
-							tab.id === 'delivery_day' &&
-							extraDeliveryFeeFormatted &&
-							extraDeliveryFee > 0
-						) {
-							title += ` +${ extraDeliveryFeeFormatted }`;
-						}
-						title += ')';
-					} else {
-						// carrierBaseCost not yet known: fall back to (+fee)
-						const fees = [ tab.displayFormatted ];
-						if (
-							tab.id === 'delivery_day' &&
-							extraDeliveryFeeFormatted &&
-							extraDeliveryFee > 0
-						) {
-							fees.push( extraDeliveryFeeFormatted );
-						}
-						title += ` (+${ fees.join( ' +' ) })`;
-					}
+				if ( tabTotal > tab.base ) {
+					const minorUnit = currency.minorUnit ?? 2;
+					const totalFormatted = formatPrice(
+						Math.round( tabTotal * Math.pow( 10, minorUnit ) ),
+						currency
+					);
+					title += ` (${ totalFormatted })`;
+				} else {
+					// carrierBase not yet available: fall back to (+fee).
+					title += ` (+${ tab.displayFormatted })`;
 				}
+			}
 
-				return { id: tab.id, name: title, base: tab.base };
-			} ),
-		[
-			baseTabs,
-			activeTab,
-			extraDeliveryFee,
-			extraDeliveryFeeFormatted,
-			carrierBaseCost,
-			currency,
-			selectedShippingFee,
-		]
-	);
+			return { id: tab.id, name: title, base: tab.base };
+		} );
+	}, [
+		baseTabs,
+		activeTab,
+		selectedShippingFee,
+		isSupportedMethod,
+		currency,
+	] );
 
-	// Retrieve customer data from WooCommerce cart store
+	// Retrieve customer data from WooCommerce cart store.
 	const customerData = useSelect(
 		( select ) => {
 			const store = select( CART_STORE_KEY );
@@ -240,15 +216,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 		} );
 	}, [] );
 
-	// When free shipping is active, clear any previously applied backend delivery fee.
-	// useEffect( () => {
-	// 	if ( selectedShippingFee === 0 ) {
-	// 		setFeeState( { extraDeliveryFee: 0, extraDeliveryFeeFormatted: '' } );
-	// 		clearBackendDeliveryFee();
-	// 	}
-	// }, [ selectedShippingFee ] );
-
-	// To prevent infinite loops if we update the address programmatically
+	// To prevent infinite loops if we update the address programmatically.
 	const isUpdatingAddress = useRef( false );
 
 	// Ref to store the previous shipping address
@@ -310,7 +278,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 				postnlData.is_nl_address_enabled &&
 				isEmpty( shippingAddress[ 'postnl/house_number' ] ) )
 		) {
-			// If we have no valid postcode/house number, hide container
+			// If we have no valid postcode/house number, hide container.
 			setShowContainer( false );
 			return;
 		}
@@ -320,7 +288,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			return;
 		}
 
-		// Check if the shipping address has changed
+		// Check if the shipping address has changed.
 		if (
 			isAddressEqual( previousShippingAddress.current, shippingAddress )
 		) {
@@ -554,6 +522,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 								deliveryOptions={ deliveryOptions }
 								isDeliveryDaysEnabled={ deliveryDaysEnabled }
 								onPriceChange={ handlePriceChange }
+								isFreeShipping={ isFreeShipping }
 							/>
 						</div>
 						{ postnlData.is_pickup_points_enabled && (

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -23,7 +23,7 @@ import { Spinner } from '@wordpress/components';
  */
 import { Block as DeliveryDayBlock } from '../postnl-delivery-day/block';
 import { Block as DropoffPointsBlock } from '../postnl-dropoff-points/block';
-import { getDeliveryDay, clearSessionData } from '../../utils/session-manager';
+import { clearSessionData } from '../../utils/session-manager';
 import {
 	batchSetExtensionData,
 	clearAllExtensionData,
@@ -71,6 +71,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 			}
 
 			const packages = store.getCartData().shippingRates || [];
+			const taxDisplayIncl = postnlData.tax_display_incl || false;
 
 			for ( const pkg of packages ) {
 				const rates = pkg.shipping_rates || [];
@@ -78,9 +79,14 @@ export const Block = ( { checkoutExtensionData } ) => {
 				if ( chosen && chosen.price !== undefined ) {
 					const minor = Number( chosen.currency_minor_unit || 0 );
 					const price = parseFloat( chosen.price );
+					const taxes = parseFloat( chosen.taxes || 0 );
 					if ( ! Number.isNaN( price ) ) {
+						const displayPrice = taxDisplayIncl
+							? price + taxes
+							: price;
 						return {
-							selectedShippingFee: price / Math.pow( 10, minor ),
+							selectedShippingFee:
+								displayPrice / Math.pow( 10, minor ),
 							selectedMethodId: chosen.method_id || '',
 						};
 					}
@@ -105,15 +111,6 @@ export const Block = ( { checkoutExtensionData } ) => {
 	// True when the selected method is one that has PostNL tab fees baked in.
 	const supportedMethods = postnlData.supported_shipping_methods || [ 'postnl' ];
 	const isSupportedMethod = supportedMethods.includes( selectedMethodId );
-
-	const [ { extraDeliveryFee, extraDeliveryFeeFormatted }, setFeeState ] =
-		useState( () => {
-			const saved = getDeliveryDay();
-			return {
-				extraDeliveryFee: Number( saved.price || 0 ),
-				extraDeliveryFeeFormatted: saved.priceFormatted || '',
-			};
-		} );
 
 	const currency = useMemo(
 		() => getCurrencyFromPriceResponse( getSetting( 'currency_data', {} ) ),
@@ -208,13 +205,6 @@ export const Block = ( { checkoutExtensionData } ) => {
 	const [ deliveryOptions, setDeliveryOptions ] = useState( [] );
 	const [ dropoffOptions, setDropoffOptions ] = useState( [] );
 	const [ deliveryDaysEnabled, setDeliveryDaysEnabled ] = useState( true );
-
-	const handlePriceChange = useCallback( ( priceData ) => {
-		setFeeState( {
-			extraDeliveryFee: priceData.numeric || 0,
-			extraDeliveryFeeFormatted: priceData.formatted || '',
-		} );
-	}, [] );
 
 	// To prevent infinite loops if we update the address programmatically.
 	const isUpdatingAddress = useRef( false );
@@ -521,7 +511,6 @@ export const Block = ( { checkoutExtensionData } ) => {
 								isActive={ activeTab === 'delivery_day' }
 								deliveryOptions={ deliveryOptions }
 								isDeliveryDaysEnabled={ deliveryDaysEnabled }
-								onPriceChange={ handlePriceChange }
 								isFreeShipping={ isFreeShipping }
 							/>
 						</div>

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -153,6 +153,8 @@ export const Block = ( { checkoutExtensionData } ) => {
 			? baseTabs.find( ( t ) => t.id === activeTab )?.base || 0
 			: 0;
 		const carrierBase = Math.max( 0, selectedShippingFee - activeTabBase );
+		const minorUnit = currency.minorUnit ?? 2;
+		const multiplier = Math.pow( 10, minorUnit );
 
 		return baseTabs.map( ( tab ) => {
 			let title =
@@ -164,9 +166,8 @@ export const Block = ( { checkoutExtensionData } ) => {
 				const tabTotal = carrierBase + tab.base;
 
 				if ( tabTotal > tab.base ) {
-					const minorUnit = currency.minorUnit ?? 2;
 					const totalFormatted = formatPrice(
-						Math.round( tabTotal * Math.pow( 10, minorUnit ) ),
+						Math.round( tabTotal * multiplier ),
 						currency
 					);
 					title += ` (${ totalFormatted })`;

--- a/client/checkout/postnl-container/block.js
+++ b/client/checkout/postnl-container/block.js
@@ -23,7 +23,7 @@ import { Spinner } from '@wordpress/components';
  */
 import { Block as DeliveryDayBlock } from '../postnl-delivery-day/block';
 import { Block as DropoffPointsBlock } from '../postnl-dropoff-points/block';
-import { clearSessionData } from '../../utils/session-manager';
+import { clearSessionData, getDeliveryDay } from '../../utils/session-manager';
 import {
 	batchSetExtensionData,
 	clearAllExtensionData,
@@ -163,11 +163,36 @@ export const Block = ( { checkoutExtensionData } ) => {
 
 	const isFreeShipping = cartDataLoaded && selectedShippingFee === 0;
 
+	const [ extraDeliveryFee, setExtraDeliveryFee ] = useState( () => {
+		const saved = getDeliveryDay();
+		return Number( saved.price || 0 );
+	} );
+
+	const handlePriceChange = useCallback( ( priceData ) => {
+		setExtraDeliveryFee( priceData.numeric || 0 );
+	}, [] );
+
 	const tabs = useMemo( () => {
+		// Don't calculate until cart data is fully loaded to avoid flicker.
+		if ( ! cartDataLoaded ) {
+			return baseTabs.map( ( tab ) => ( {
+				id: tab.id,
+				name:
+					tab.id === 'delivery_day'
+						? __( 'Delivery', 'postnl-for-woocommerce' )
+						: __( 'Pickup', 'postnl-for-woocommerce' ),
+				base: tab.base,
+			} ) );
+		}
+
 		const activeTabBase = isSupportedMethod
 			? baseTabs.find( ( t ) => t.id === activeTab )?.base || 0
 			: 0;
-		const carrierBase = Math.max( 0, selectedShippingFee - activeTabBase );
+		const activeExtra = isSupportedMethod
+			? activeTabBase +
+			( activeTab === 'delivery_day' ? extraDeliveryFee : 0 )
+			: 0;
+		const carrierBase = Math.max( 0, selectedShippingFee - activeExtra );
 		const minorUnit = currency.minorUnit ?? 2;
 		const multiplier = Math.pow( 10, minorUnit );
 
@@ -177,17 +202,17 @@ export const Block = ( { checkoutExtensionData } ) => {
 					? __( 'Delivery', 'postnl-for-woocommerce' )
 					: __( 'Pickup', 'postnl-for-woocommerce' );
 
-			if ( tab.base > 0 && selectedShippingFee > 0 ) {
-				const tabTotal = carrierBase + tab.base;
+			if ( selectedShippingFee > 0 ) {
+				const extra = tab.id === 'delivery_day' ? extraDeliveryFee : 0;
+				const tabTotal = carrierBase + tab.base + extra;
 
-				if ( tabTotal > tab.base ) {
+				if ( tabTotal > 0 ) {
 					const totalFormatted = formatPrice(
 						Math.round( tabTotal * multiplier ),
 						currency
 					);
 					title += ` (${ totalFormatted })`;
-				} else {
-					// carrierBase not yet available: fall back to (+fee).
+				} else if ( tab.base > 0 ) {
 					title += ` (+${ tab.displayFormatted })`;
 				}
 			}
@@ -200,6 +225,8 @@ export const Block = ( { checkoutExtensionData } ) => {
 		selectedShippingFee,
 		isSupportedMethod,
 		currency,
+		extraDeliveryFee,
+		cartDataLoaded,
 	] );
 
 	// Retrieve customer data from WooCommerce cart store.
@@ -527,8 +554,7 @@ export const Block = ( { checkoutExtensionData } ) => {
 								isActive={ activeTab === 'delivery_day' }
 								deliveryOptions={ deliveryOptions }
 								isDeliveryDaysEnabled={ deliveryDaysEnabled }
-								isFreeShipping={ isFreeShipping }
-							/>
+								isFreeShipping={ isFreeShipping }							onPriceChange={ handlePriceChange }							/>
 						</div>
 						{ postnlData.is_pickup_points_enabled && (
 							<div

--- a/client/checkout/postnl-delivery-day/block.js
+++ b/client/checkout/postnl-delivery-day/block.js
@@ -45,6 +45,7 @@ export const Block = ( {
 	deliveryOptions,
 	isDeliveryDaysEnabled,
 	onPriceChange = () => {},
+	isFreeShipping = false,
 } ) => {
 	const { setExtensionData } = checkoutExtensionData;
 
@@ -129,18 +130,23 @@ export const Block = ( {
 				firstDelivery.options.length > 0
 			) {
 				const firstOption = firstDelivery.options[ 0 ];
+				const effectivePrice = isFreeShipping
+					? 0
+					: firstOption.price || 0;
 				handleOptionChange(
 					`${ firstDelivery.date }_${ firstOption.from }-${ firstOption.to }_${ firstOption.price }`,
 					firstDelivery.date,
 					firstOption.from,
 					firstOption.to,
 					firstOption.type || 'Unknown',
-					firstOption.price || 0,
-					firstOption.price_formatted || ''
+					effectivePrice,
+					isFreeShipping ? '' : firstOption.price_formatted || ''
 				);
 				onPriceChange( {
-					numeric: Number( firstOption.price || 0 ),
-					formatted: firstOption.price_formatted || '',
+					numeric: effectivePrice,
+					formatted: isFreeShipping
+						? ''
+						: firstOption.price_formatted || '',
 				} );
 			}
 		}
@@ -301,13 +307,18 @@ export const Block = ( {
 																	from,
 																	to,
 																	optionType,
-																	price,
-																	priceDisplayFormatted
+																	isFreeShipping
+																		? 0
+																		: price,
+																	isFreeShipping
+																		? ''
+																		: priceDisplayFormatted
 																)
 															}
 														/>
 														{ priceDisplayFormatted &&
-															price > 0 && (
+															price > 0 &&
+															! isFreeShipping && (
 																<i>
 																	+
 																	{

--- a/client/checkout/postnl-delivery-day/block.js
+++ b/client/checkout/postnl-delivery-day/block.js
@@ -133,6 +133,9 @@ export const Block = ( {
 				const effectivePrice = isFreeShipping
 					? 0
 					: firstOption.price || 0;
+				const effectivePriceDisplay = isFreeShipping
+					? 0
+					: ( firstOption.price_display ?? effectivePrice );
 				handleOptionChange(
 					`${ firstDelivery.date }_${ firstOption.from }-${ firstOption.to }_${ firstOption.price }`,
 					firstDelivery.date,
@@ -140,10 +143,11 @@ export const Block = ( {
 					firstOption.to,
 					firstOption.type || 'Unknown',
 					effectivePrice,
-					isFreeShipping ? '' : firstOption.price_formatted || ''
+					isFreeShipping ? '' : firstOption.price_formatted || '',
+					effectivePriceDisplay
 				);
 				onPriceChange( {
-					numeric: effectivePrice,
+					numeric: effectivePriceDisplay,
 					formatted: isFreeShipping
 						? ''
 						: firstOption.price_formatted || '',
@@ -159,10 +163,13 @@ export const Block = ( {
 		to,
 		type,
 		price,
-		priceFormatted = ''
+		priceFormatted = '',
+		priceDisplay = null
 	) => {
 		const deliveryDayValue = `${ deliveryDate }_${ from }-${ to }_${ price }`;
 		const numericPrice = Number( price );
+		// Use tax-inclusive display price for tab fee calculations; fall back to raw price.
+		const displayNumericPrice = priceDisplay !== null ? Number( priceDisplay ) : numericPrice;
 
 		// Build selection data once
 		const selectionData = {
@@ -199,8 +206,9 @@ export const Block = ( {
 			type,
 		} );
 
-		// Notify parent of price change
-		onPriceChange( { numeric: numericPrice, formatted: priceFormatted } );
+		// Notify parent of price change (use tax-inclusive display price so it
+		// matches the tax-inclusive baseTabs.base values used in the container).
+		onPriceChange( { numeric: displayNumericPrice, formatted: priceFormatted } );
 
 		// Clear dropoff point data
 		clearDropoffPoint();
@@ -251,6 +259,9 @@ export const Block = ( {
 											const optionType =
 												option.type || 'Unknown';
 											const price = option.price || 0;
+											const priceDisplayNumeric = isFreeShipping
+												? 0
+												: ( option.price_display ?? price );
 											const priceDisplayFormatted =
 												option.price_formatted || '';
 											const value = `${ delivery.date }_${ from }-${ to }_${ price }`;
@@ -312,7 +323,8 @@ export const Block = ( {
 																		: price,
 																	isFreeShipping
 																		? ''
-																		: priceDisplayFormatted
+																		: priceDisplayFormatted,
+																	priceDisplayNumeric
 																)
 															}
 														/>

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -235,8 +235,11 @@ class Blocks_Integration implements IntegrationInterface {
 	 * @return array
 	 */
 	public function get_script_data() {
-		$letterbox = Utils::is_cart_eligible_auto_letterbox( WC()->cart );
-		$settings  = postnl()->get_shipping_settings();
+		$letterbox        = Utils::is_cart_eligible_auto_letterbox( WC()->cart );
+		$settings         = postnl()->get_shipping_settings();
+		$delivery_day_fee = (float) $settings->get_delivery_days_fee();
+		$pickup_fee       = (float) $settings->get_pickup_delivery_fee();
+		$base_rate        = Utils::get_chosen_postnl_base_rate_cost();
 
 		return array(
 			'ajax_url'                     => admin_url( 'admin-ajax.php' ),
@@ -251,10 +254,12 @@ class Blocks_Integration implements IntegrationInterface {
 				'is_fill_in_with_postnl_enabled' => $this->fill_in_with_settings->is_fill_in_with_postnl_enabled(),
 				'postnl_logo_url'                => POSTNL_WC_PLUGIN_DIR_URL . '/assets/images/postnl-logo.svg',
 			),
-			'delivery_day_fee'           => $settings->get_delivery_days_fee(),
-			'delivery_day_fee_formatted' => Utils::get_formatted_fee_total_price( $settings->get_delivery_days_fee() ),
-			'pickup_fee'                 => $settings->get_pickup_delivery_fee(),
-			'pickup_fee_formatted'       => Utils::get_formatted_fee_total_price( $settings->get_pickup_delivery_fee() ),
+			'delivery_day_fee'             => $delivery_day_fee,
+			'delivery_day_fee_formatted'   => Utils::get_formatted_fee_total_price( $delivery_day_fee ),
+			'delivery_day_total_formatted' => Utils::get_formatted_fee_total_price( $base_rate + $delivery_day_fee ),
+			'pickup_fee'                   => $pickup_fee,
+			'pickup_fee_formatted'         => Utils::get_formatted_fee_total_price( $pickup_fee ),
+			'pickup_total_formatted'       => Utils::get_formatted_fee_total_price( $base_rate + $pickup_fee ),
 		);
 	}
 }

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -260,6 +260,7 @@ class Blocks_Integration implements IntegrationInterface {
 			'pickup_fee'                   => $pickup_fee,
 			'pickup_fee_formatted'         => Utils::get_formatted_fee_total_price( $pickup_fee ),
 			'pickup_total_formatted'       => Utils::get_formatted_fee_total_price( $base_rate + $pickup_fee ),
+			'supported_shipping_methods'   => $settings->get_supported_shipping_methods(),
 		);
 	}
 }

--- a/src/Checkout_Blocks/Blocks_Integration.php
+++ b/src/Checkout_Blocks/Blocks_Integration.php
@@ -237,9 +237,11 @@ class Blocks_Integration implements IntegrationInterface {
 	public function get_script_data() {
 		$letterbox        = Utils::is_cart_eligible_auto_letterbox( WC()->cart );
 		$settings         = postnl()->get_shipping_settings();
-		$delivery_day_fee = (float) $settings->get_delivery_days_fee();
-		$pickup_fee       = (float) $settings->get_pickup_delivery_fee();
-		$base_rate        = Utils::get_chosen_postnl_base_rate_cost();
+		$delivery_day_fee          = (float) $settings->get_delivery_days_fee();
+		$pickup_fee                = (float) $settings->get_pickup_delivery_fee();
+		$delivery_day_fee_display  = Utils::get_fee_total_price( $delivery_day_fee );
+		$pickup_fee_display        = Utils::get_fee_total_price( $pickup_fee );
+		$base_rate                 = Utils::get_chosen_shipping_rate_cost();
 
 		return array(
 			'ajax_url'                     => admin_url( 'admin-ajax.php' ),
@@ -254,13 +256,14 @@ class Blocks_Integration implements IntegrationInterface {
 				'is_fill_in_with_postnl_enabled' => $this->fill_in_with_settings->is_fill_in_with_postnl_enabled(),
 				'postnl_logo_url'                => POSTNL_WC_PLUGIN_DIR_URL . '/assets/images/postnl-logo.svg',
 			),
-			'delivery_day_fee'             => $delivery_day_fee,
+			'delivery_day_fee'             => $delivery_day_fee_display,
 			'delivery_day_fee_formatted'   => Utils::get_formatted_fee_total_price( $delivery_day_fee ),
 			'delivery_day_total_formatted' => Utils::get_formatted_fee_total_price( $base_rate + $delivery_day_fee ),
-			'pickup_fee'                   => $pickup_fee,
+			'pickup_fee'                   => $pickup_fee_display,
 			'pickup_fee_formatted'         => Utils::get_formatted_fee_total_price( $pickup_fee ),
 			'pickup_total_formatted'       => Utils::get_formatted_fee_total_price( $base_rate + $pickup_fee ),
 			'supported_shipping_methods'   => $settings->get_supported_shipping_methods(),
+			'tax_display_incl'             => 'incl' === get_option( 'woocommerce_tax_display_cart', 'excl' ),
 		);
 	}
 }

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -206,6 +206,11 @@ class Extend_Block_Core {
 				continue;
 			}
 
+			// Do not add PostNL fees when the shipping rate is already free.
+			if ( 0 >= (float) $rate->cost ) {
+				continue;
+			}
+
 			$extra = 0;
 
 			if ( 'Pickup' === $session_type && $pickup_fee > 0 ) {

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -144,6 +144,12 @@ class Extend_Block_Core {
 			WC()->session->__unset( 'postnl_delivery_fee' );
 			WC()->session->__unset( 'postnl_delivery_type' );
 		}
+
+		// Clear the WooCommerce shipping rate cache so that add_postnl_fees_to_rates
+		// is re-applied with the updated morning/evening fee on the next cart response.
+		foreach ( WC()->cart->get_shipping_packages() as $package_key => $package ) {
+			WC()->session->__unset( 'shipping_for_package_' . $package_key );
+		}
 	}
 
 	/**
@@ -156,19 +162,9 @@ class Extend_Block_Core {
 			return;
 		}
 
-		// Get the fee amount and type from session
-		$fee_amount = WC()->session->get( 'postnl_delivery_fee', 0 );
-		$fee_type   = WC()->session->get( 'postnl_delivery_type', '' );
-
-		$fee_label = __( 'PostNL Delivery Fee', 'postnl-for-woocommerce' );
-		if ( '08:00-12:00' === $fee_type || 'Morning' === $fee_type ) {
-			$fee_label = __( 'PostNL Morning Fee', 'postnl-for-woocommerce' );
-		} elseif ( 'Evening' === $fee_type ) {
-			$fee_label = __( 'PostNL Evening Fee', 'postnl-for-woocommerce' );
-		} else {
-			return;
-		}
-
+		// Morning/Evening fees are now baked into the shipping rate cost via
+		// add_postnl_fees_to_rates(), so we only need to clear any previously
+		// added PostNL cart fee lines to avoid stale entries.
 		$new_fees = array();
 		foreach ( $cart->get_fees() as $fee ) {
 			if ( strpos( $fee->name, 'PostNL' ) === false ) {
@@ -176,15 +172,6 @@ class Extend_Block_Core {
 			}
 		}
 		$cart->fees_api()->set_fees( $new_fees );
-
-		// If the chosen shipping rate is free, morning/evening fees are also free.
-		if ( $this->is_chosen_shipping_free() ) {
-			return;
-		}
-
-		if ( $fee_amount > 0 ) {
-			$cart->add_fee( $fee_label, $fee_amount, true );
-		}
 	}
 
 	/**
@@ -210,9 +197,33 @@ class Extend_Block_Core {
 			return $rates;
 		}
 
-		$pickup_fee   = $this->settings->get_pickup_delivery_fee();
-		$base_day_fee = $this->settings->get_delivery_days_fee();
-		$supported    = $this->settings->get_supported_shipping_methods();
+		$supported = $this->settings->get_supported_shipping_methods();
+
+		// If free shipping is available for this package (threshold met or coupon
+		// applied), zero out the cost of all supported methods and skip adding fees.
+		$has_free_shipping = false;
+		foreach ( $rates as $rate ) {
+			if ( 'free_shipping' === $rate->get_method_id() ) {
+				$has_free_shipping = true;
+				break;
+			}
+		}
+
+		if ( $has_free_shipping ) {
+			foreach ( $rates as $rate_id => $rate ) {
+				if ( ! in_array( $rate->get_method_id(), $supported, true ) ) {
+					continue;
+				}
+				$rate->cost  = 0;
+				$rate->taxes = array();
+			}
+			return $rates;
+		}
+
+		$pickup_fee            = $this->settings->get_pickup_delivery_fee();
+		$base_day_fee          = $this->settings->get_delivery_days_fee();
+		$morning_evening_fee   = (float) WC()->session->get( 'postnl_delivery_fee', 0 );
+		$is_morning_or_evening = in_array( $session_type, array( 'Morning', '08:00-12:00', 'Evening' ), true );
 
 		foreach ( $rates as $rate_id => $rate ) {
 
@@ -233,7 +244,13 @@ class Extend_Block_Core {
 				$extra = $base_day_fee;
 			}
 
-			if ( 0 === $extra ) {
+			// Add morning/evening fee directly to the rate so it doesn't
+			// appear as a separate cart fee line.
+			if ( $is_morning_or_evening && $morning_evening_fee > 0 ) {
+				$extra += $morning_evening_fee;
+			}
+
+			if ( 0 == $extra ) {
 				continue;
 			}
 

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -177,9 +177,40 @@ class Extend_Block_Core {
 		}
 		$cart->fees_api()->set_fees( $new_fees );
 
+		// If the chosen shipping rate is free, morning/evening fees are also free.
+		if ( $this->is_chosen_shipping_free() ) {
+			return;
+		}
+
 		if ( $fee_amount > 0 ) {
 			$cart->add_fee( $fee_label, $fee_amount, true );
 		}
+	}
+
+	/**
+	 * Checks whether the currently chosen shipping rate has zero cost.
+	 *
+	 * @return bool
+	 */
+	private function is_chosen_shipping_free(): bool {
+		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+		if ( empty( $chosen_methods ) ) {
+			return false;
+		}
+
+		$packages = WC()->shipping()->get_packages();
+
+		foreach ( $packages as $i => $package ) {
+			$chosen_key = $chosen_methods[ $i ] ?? '';
+			if ( empty( $chosen_key ) || ! isset( $package['rates'][ $chosen_key ] ) ) {
+				continue;
+			}
+			if ( 0 >= (float) $package['rates'][ $chosen_key ]->cost ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -193,24 +193,7 @@ class Extend_Block_Core {
 	 * @return bool
 	 */
 	private function is_chosen_shipping_free(): bool {
-		$chosen_methods = WC()->session->get( 'chosen_shipping_methods', array() );
-		if ( empty( $chosen_methods ) ) {
-			return false;
-		}
-
-		$packages = WC()->shipping()->get_packages();
-
-		foreach ( $packages as $i => $package ) {
-			$chosen_key = $chosen_methods[ $i ] ?? '';
-			if ( empty( $chosen_key ) || ! isset( $package['rates'][ $chosen_key ] ) ) {
-				continue;
-			}
-			if ( 0 >= (float) $package['rates'][ $chosen_key ]->cost ) {
-				return true;
-			}
-		}
-
-		return false;
+		return Utils::get_chosen_shipping_rate_cost() <= 0.0;
 	}
 
 	/**

--- a/src/Frontend/Base.php
+++ b/src/Frontend/Base.php
@@ -105,7 +105,6 @@ abstract class Base {
 		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'save_data' ), 10, 2 );
 		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'save_letterbox_data' ), 13, 2 );
 		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'save_default_data' ), 15, 2 );
-		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'calculate_non_standard_fee' ), 20, 2 );
 		add_filter( 'postnl_frontend_checkout_tab', array( $this, 'add_checkout_tab' ), 10, 2 );
 		add_action( 'postnl_checkout_content', array( $this, 'display_content' ), 10, 2 );
 		add_filter( 'woocommerce_email_order_meta_fields', array( $this, 'add_pickup_points_fields_to_email' ), 10, 3 );
@@ -388,70 +387,6 @@ abstract class Base {
 		}
 
 		$order->update_meta_data( $this->meta_name, $data );
-		$order->save();
-	}
-
-	/**
-	 * Calculate non standard delivery day fee.
-	 *
-	 * @param array $order_id ID of order post.
-	 * @param array $posted_data Array of global _POST data.
-	 *
-	 * @return void
-	 */
-	public function calculate_non_standard_fee( $order_id, $posted_data ) {
-		$order = wc_get_order( $order_id );
-
-		if ( ! is_a( $order, 'WC_Order' ) ) {
-			return;
-		}
-
-		$chosen_rate_cost = Utils::get_chosen_shipping_rate_cost();
-		if ( $chosen_rate_cost <= 0 ) {
-			return;
-		}
-
-		$data = $this->get_data( $order->get_id() );
-
-		$add_optional_fee  = true;
-		$non_standard_fees = self::non_standard_fees_data();
-
-		foreach ( $non_standard_fees as $type => $fee ) {
-			if ( ! isset( $data['frontend'][ $fee['condition']['key'] ] ) ) {
-				continue;
-			}
-
-			if ( $type === $data['frontend'][ $fee['condition']['key'] ] ) {
-				$fee_name  = $fee['fee_name'];
-				$fee_price = $fee['fee_price'];
-				break;
-			}
-		}
-
-		if ( ! isset( $fee_name ) ) {
-			return;
-		}
-
-		foreach ( $order->get_fees() as $item_fee ) {
-			if ( $item_fee->get_name() === $fee_name ) {
-				$add_optional_fee = false;
-			}
-		}
-
-		if ( true === $add_optional_fee ) {
-			$item_fee = new \WC_Order_Item_Fee();
-
-			$item_fee->set_name( $fee_name );
-			$item_fee->set_amount( $fee_price );
-			$item_fee->set_tax_class( '' );
-			$item_fee->set_tax_status( 'taxable' );
-			$item_fee->set_total( $fee_price );
-
-			$order->add_item( $item_fee );
-
-			$order->calculate_totals();
-		}
-
 		$order->save();
 	}
 

--- a/src/Frontend/Base.php
+++ b/src/Frontend/Base.php
@@ -406,6 +406,11 @@ abstract class Base {
 			return;
 		}
 
+		$chosen_rate_cost = Utils::get_chosen_shipping_rate_cost();
+		if ( $chosen_rate_cost <= 0 ) {
+			return;
+		}
+
 		$data = $this->get_data( $order->get_id() );
 
 		$add_optional_fee  = true;

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -263,20 +263,26 @@ class Container {
 			return;
 		}
 
+		$delivery_day_fee = (float) $this->settings->get_delivery_days_fee();
+		$pickup_fee       = (float) $this->settings->get_pickup_delivery_fee();
+		$base_rate        = Utils::get_chosen_postnl_base_rate_cost();
+
 		$template_args = array(
-			'tabs'             => $this->get_available_tabs( $checkout_data['response'] ),
-			'response'         => $checkout_data['response'],
-			'post_data'        => $checkout_data['post_data'],
-			'default_val'      => $this->get_default_value( $checkout_data['response'], $checkout_data['post_data'] ),
-			'letterbox'        => $checkout_data['letterbox'],
-			'fields'           => array(
+			'tabs'                          => $this->get_available_tabs( $checkout_data['response'] ),
+			'response'                      => $checkout_data['response'],
+			'post_data'                     => $checkout_data['post_data'],
+			'default_val'                   => $this->get_default_value( $checkout_data['response'], $checkout_data['post_data'] ),
+			'letterbox'                     => $checkout_data['letterbox'],
+			'fields'                        => array(
 				array(
 					'name'  => $this->tab_field,
 					'value' => $this->get_tab_field_value( $checkout_data['post_data'] ),
 				),
 			),
-			'pickup_fee'       => (float) $this->settings->get_pickup_delivery_fee(),
-			'delivery_day_fee' => (float) $this->settings->get_delivery_days_fee(),
+			'pickup_fee'                    => $pickup_fee,
+			'delivery_day_fee'              => $delivery_day_fee,
+			'delivery_day_total_formatted'  => Utils::get_formatted_fee_total_price( $base_rate + $delivery_day_fee ),
+			'pickup_total_formatted'        => Utils::get_formatted_fee_total_price( $base_rate + $pickup_fee ),
 		);
 
 		wc_get_template( 'checkout/postnl-container.php', $template_args, '', POSTNL_WC_PLUGIN_DIR_PATH . '/templates/' );

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -265,7 +265,9 @@ class Container {
 
 		$delivery_day_fee = (float) $this->settings->get_delivery_days_fee();
 		$pickup_fee       = (float) $this->settings->get_pickup_delivery_fee();
-		$base_rate        = Utils::get_chosen_postnl_base_rate_cost();
+		$active_option = WC()->session ? WC()->session->get( 'postnl_option', 'delivery_day' ) : 'delivery_day';
+		$injected_fee  = ( 'dropoff_points' === $active_option ) ? $pickup_fee : $delivery_day_fee;
+		$carrier_base  = max( 0.0, Utils::get_chosen_shipping_rate_cost() - $injected_fee );
 
 		$template_args = array(
 			'tabs'                          => $this->get_available_tabs( $checkout_data['response'] ),
@@ -281,8 +283,8 @@ class Container {
 			),
 			'pickup_fee'                    => $pickup_fee,
 			'delivery_day_fee'              => $delivery_day_fee,
-			'delivery_day_total_formatted'  => Utils::get_formatted_fee_total_price( $base_rate + $delivery_day_fee ),
-			'pickup_total_formatted'        => Utils::get_formatted_fee_total_price( $base_rate + $pickup_fee ),
+			'delivery_day_total_formatted'  => Utils::get_formatted_fee_total_price( $carrier_base + $delivery_day_fee ),
+			'pickup_total_formatted'        => Utils::get_formatted_fee_total_price( $carrier_base + $pickup_fee ),
 		);
 
 		wc_get_template( 'checkout/postnl-container.php', $template_args, '', POSTNL_WC_PLUGIN_DIR_PATH . '/templates/' );
@@ -436,6 +438,11 @@ class Container {
 		$post_data = $this->get_checkout_post_data();
 
 		if ( empty( $post_data ) ) {
+			return;
+		}
+
+		// If the chosen shipping rate is free, morning/evening fees are also free.
+		if ( 0 >= Utils::get_chosen_shipping_rate_cost() ) {
 			return;
 		}
 

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -209,7 +209,7 @@ class Container {
 			}
 
 			$options = array_map(
-				function ( $timeframe ) use ( $non_standard_fees ) {
+				function ( $timeframe ) use ( $non_standard_fees, $is_free_shipping ) {
 					$type  = array_shift( $timeframe['Options'] );
 					$price = isset( $non_standard_fees[ $type ] ) && ! $is_free_shipping ? $non_standard_fees[ $type ]['fee_price'] : 0;
 

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -270,9 +270,9 @@ class Container {
 
 		$delivery_day_fee = $is_free_shipping ? 0.0 : (float) $this->settings->get_delivery_days_fee();
 		$pickup_fee       = $is_free_shipping ? 0.0 : (float) $this->settings->get_pickup_delivery_fee();
-		$active_option = WC()->session ? WC()->session->get( 'postnl_option', 'delivery_day' ) : 'delivery_day';
-		$injected_fee  = ( 'dropoff_points' === $active_option ) ? $pickup_fee : $delivery_day_fee;
-		$carrier_base  = $is_free_shipping ? 0.0 : max( 0.0, $chosen_rate_cost - $injected_fee );
+		$active_option    = WC()->session ? WC()->session->get( 'postnl_option', 'delivery_day' ) : 'delivery_day';
+		$injected_fee     = ( 'dropoff_points' === $active_option ) ? $pickup_fee : $delivery_day_fee;
+		$carrier_base     = $is_free_shipping ? 0.0 : max( 0.0, $chosen_rate_cost - $injected_fee );
 
 		$template_args = array(
 			'tabs'                          => $this->get_available_tabs( $checkout_data['response'] ),

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -200,6 +200,8 @@ class Container {
 		}
 
 		$non_standard_fees = Base::non_standard_fees_data();
+		$chosen_rate_cost = Utils::get_chosen_shipping_rate_cost();
+		$is_free_shipping = $chosen_rate_cost <= 0;
 
 		foreach ( $response['DeliveryOptions'] as $delivery_option ) {
 			if ( empty( $delivery_option['DeliveryDate'] ) || empty( $delivery_option['Timeframe'] ) ) {
@@ -209,7 +211,7 @@ class Container {
 			$options = array_map(
 				function ( $timeframe ) use ( $non_standard_fees ) {
 					$type  = array_shift( $timeframe['Options'] );
-					$price = isset( $non_standard_fees[ $type ] ) ? $non_standard_fees[ $type ]['fee_price'] : 0;
+					$price = isset( $non_standard_fees[ $type ] ) && ! $is_free_shipping ? $non_standard_fees[ $type ]['fee_price'] : 0;
 
 					return array(
 						'from'  => Utils::get_hour_min( $timeframe['From'] ),
@@ -263,11 +265,14 @@ class Container {
 			return;
 		}
 
-		$delivery_day_fee = (float) $this->settings->get_delivery_days_fee();
-		$pickup_fee       = (float) $this->settings->get_pickup_delivery_fee();
+		$chosen_rate_cost = Utils::get_chosen_shipping_rate_cost();
+		$is_free_shipping = $chosen_rate_cost <= 0;
+
+		$delivery_day_fee = $is_free_shipping ? 0.0 : (float) $this->settings->get_delivery_days_fee();
+		$pickup_fee       = $is_free_shipping ? 0.0 : (float) $this->settings->get_pickup_delivery_fee();
 		$active_option = WC()->session ? WC()->session->get( 'postnl_option', 'delivery_day' ) : 'delivery_day';
 		$injected_fee  = ( 'dropoff_points' === $active_option ) ? $pickup_fee : $delivery_day_fee;
-		$carrier_base  = max( 0.0, Utils::get_chosen_shipping_rate_cost() - $injected_fee );
+		$carrier_base  = $is_free_shipping ? 0.0 : max( 0.0, $chosen_rate_cost - $injected_fee );
 
 		$template_args = array(
 			'tabs'                          => $this->get_available_tabs( $checkout_data['response'] ),
@@ -473,6 +478,11 @@ class Container {
 
 		foreach ( $rates as $rate_id => $rate ) {
 			if ( ! in_array( $rate->get_method_id(), $supported, true ) ) {
+				continue;
+			}
+
+			// Do not add PostNL tab fees on top of free shipping.
+			if ( (float) $rate->cost <= 0 ) {
 				continue;
 			}
 

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -55,7 +55,6 @@ class Container {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts_styles' ) );
 
 		add_action( 'woocommerce_review_order_after_shipping', array( $this, 'postnl_fields' ), 10 );
-		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees' ), 10, 1 );
 
 		add_filter( 'woocommerce_update_order_review_fragments', array( $this, 'fill_validated_address' ) );
 		add_filter( 'woocommerce_cart_shipping_method_full_label', array( $this, 'add_shipping_method_icon' ), 10, 2 );
@@ -258,7 +257,6 @@ class Container {
 	 * @throws \Exception.
 	 */
 	public function display_fields( $post_data ) {
-
 		$checkout_data = $this->get_checkout_data( $post_data );
 
 		if ( empty( $checkout_data['response'] ) ) {
@@ -271,25 +269,39 @@ class Container {
 		$delivery_day_fee = $is_free_shipping ? 0.0 : (float) $this->settings->get_delivery_days_fee();
 		$pickup_fee       = $is_free_shipping ? 0.0 : (float) $this->settings->get_pickup_delivery_fee();
 		$active_option    = WC()->session ? WC()->session->get( 'postnl_option', 'delivery_day' ) : 'delivery_day';
-		$injected_fee     = ( 'dropoff_points' === $active_option ) ? $pickup_fee : $delivery_day_fee;
-		$carrier_base     = $is_free_shipping ? 0.0 : max( 0.0, $chosen_rate_cost - $injected_fee );
+
+		// Get morning/evening fee — only relevant when delivery_day tab is active.
+		$non_standard_fees   = Base::non_standard_fees_data();
+		$is_non_standard     = ! $is_free_shipping
+			&& 'delivery_day' === $active_option
+			&& ! empty( $post_data['postnl_delivery_day_type'] )
+			&& isset( $non_standard_fees[ $post_data['postnl_delivery_day_type'] ] );
+		$morning_evening_fee = $is_non_standard ? (float) ( $post_data['postnl_delivery_day_price'] ?? 0 ) : 0.0;
+
+		// Subtract the full injected fee (including morning/evening) from the rate cost
+		$injected_fee = ( 'dropoff_points' === $active_option )
+			? $pickup_fee
+			: $delivery_day_fee + $morning_evening_fee;
+
+		$carrier_base = $is_free_shipping ? 0.0 : max( 0.0, $chosen_rate_cost - $injected_fee );
 
 		$template_args = array(
-			'tabs'                          => $this->get_available_tabs( $checkout_data['response'] ),
-			'response'                      => $checkout_data['response'],
-			'post_data'                     => $checkout_data['post_data'],
-			'default_val'                   => $this->get_default_value( $checkout_data['response'], $checkout_data['post_data'] ),
-			'letterbox'                     => $checkout_data['letterbox'],
-			'fields'                        => array(
+			'tabs'                         => $this->get_available_tabs( $checkout_data['response'] ),
+			'response'                     => $checkout_data['response'],
+			'post_data'                    => $checkout_data['post_data'],
+			'default_val'                  => $this->get_default_value( $checkout_data['response'], $checkout_data['post_data'] ),
+			'letterbox'                    => $checkout_data['letterbox'],
+			'fields'                       => array(
 				array(
 					'name'  => $this->tab_field,
 					'value' => $this->get_tab_field_value( $checkout_data['post_data'] ),
 				),
 			),
-			'pickup_fee'                    => $pickup_fee,
-			'delivery_day_fee'              => $delivery_day_fee,
-			'delivery_day_total_formatted'  => Utils::get_formatted_fee_total_price( $carrier_base + $delivery_day_fee ),
-			'pickup_total_formatted'        => Utils::get_formatted_fee_total_price( $carrier_base + $pickup_fee ),
+			'pickup_fee'                   => $pickup_fee,
+			'delivery_day_fee'             => $delivery_day_fee,
+			'carrier_base'                 => $carrier_base,
+			'delivery_day_total_formatted' => Utils::get_formatted_fee_total_price( $carrier_base + $delivery_day_fee + $morning_evening_fee ),
+			'pickup_total_formatted'       => Utils::get_formatted_fee_total_price( $carrier_base + $pickup_fee ),
 		);
 
 		wc_get_template( 'checkout/postnl-container.php', $template_args, '', POSTNL_WC_PLUGIN_DIR_PATH . '/templates/' );
@@ -435,30 +447,6 @@ class Container {
 	}
 
 	/**
-	 * Add cart fees.
-	 *
-	 * @param \WC_Cart $cart Cart object.
-	 */
-	public function add_cart_fees( $cart ) {
-		$post_data = $this->get_checkout_post_data();
-
-		if ( empty( $post_data ) ) {
-			return;
-		}
-
-		// If the chosen shipping rate is free, morning/evening fees are also free.
-		if ( 0 >= Utils::get_chosen_shipping_rate_cost() ) {
-			return;
-		}
-
-		$non_standard_fees        = Base::non_standard_fees_data();
-		$is_non_standard_delivery = ! empty( $post_data['postnl_delivery_day_type'] ) && isset( $non_standard_fees[ $post_data['postnl_delivery_day_type'] ] );
-
-		if ( ! empty( $post_data['postnl_delivery_day_price'] ) && 'delivery_day' === $post_data['postnl_option'] && $is_non_standard_delivery ) {
-			$cart->add_fee( $non_standard_fees[ $post_data['postnl_delivery_day_type'] ]['fee_name'], wc_format_decimal( $post_data['postnl_delivery_day_price'] ), true );
-		}
-	}
-	/**
 	 * ِAdd the shipping option fees to the shipping methods
 	 *
 	 * @param array $rates.
@@ -472,9 +460,43 @@ class Container {
 			return $rates;
 		}
 
+		$supported = $this->settings->get_supported_shipping_methods();
+
+		// If free shipping is available for this package, zero out the cost of all
+		// supported methods and skip adding PostNL fees.
+		$has_free_shipping = false;
+		foreach ( $rates as $rate ) {
+			if ( 'free_shipping' === $rate->get_method_id() ) {
+				$has_free_shipping = true;
+				break;
+			}
+		}
+
+		if ( $has_free_shipping ) {
+			foreach ( $rates as $rate_id => $rate ) {
+				if ( ! in_array( $rate->get_method_id(), $supported, true ) ) {
+					continue;
+				}
+				$rate->cost  = 0;
+				$rate->taxes = array();
+			}
+			return $rates;
+		}
+
 		$pickup_fee   = (float) $this->settings->get_pickup_delivery_fee();
 		$base_day_fee = (float) $this->settings->get_delivery_days_fee();
-		$supported    = $this->settings->get_supported_shipping_methods();
+
+		// Get morning/evening surcharge from package destination.
+		$morning_evening_fee = 0.0;
+		if ( 'delivery_day' === $option ) {
+			$non_standard_fees  = Base::non_standard_fees_data();
+			$delivery_day_type  = $package['destination']['postnl_delivery_day_type'] ?? '';
+			$delivery_day_price = $package['destination']['postnl_delivery_day_price'] ?? 0;
+
+			if ( ! empty( $delivery_day_type ) && isset( $non_standard_fees[ $delivery_day_type ] ) && $delivery_day_price > 0 ) {
+				$morning_evening_fee = (float) $delivery_day_price;
+			}
+		}
 
 		foreach ( $rates as $rate_id => $rate ) {
 			if ( ! in_array( $rate->get_method_id(), $supported, true ) ) {
@@ -489,8 +511,8 @@ class Container {
 			$extra = 0;
 			if ( 'dropoff_points' === $option && $pickup_fee > 0 ) {
 				$extra = $pickup_fee;
-			} elseif ( 'delivery_day' === $option && $base_day_fee > 0 ) {
-				$extra = $base_day_fee;
+			} elseif ( 'delivery_day' === $option ) {
+				$extra = $base_day_fee + $morning_evening_fee;
 			}
 
 			if ( $extra <= 0 ) {
@@ -508,7 +530,6 @@ class Container {
 		return $rates;
 	}
 
-
 	/**
 	 * Include the selected PostNL option in the shipping package
 	 *
@@ -525,8 +546,13 @@ class Container {
 
 		WC()->session->set( 'postnl_option', $option );
 
+		$delivery_day_type  = $post_data['postnl_delivery_day_type'] ?? '';
+		$delivery_day_price = $post_data['postnl_delivery_day_price'] ?? '';
+
 		foreach ( $packages as $key => $package ) {
-			$packages[ $key ]['destination']['postnl_option'] = $option;
+			$packages[ $key ]['destination']['postnl_option']             = $option;
+			$packages[ $key ]['destination']['postnl_delivery_day_type']  = $delivery_day_type;
+			$packages[ $key ]['destination']['postnl_delivery_day_price'] = $delivery_day_price;
 		}
 
 		return $packages;

--- a/src/Frontend/Delivery_Day.php
+++ b/src/Frontend/Delivery_Day.php
@@ -132,6 +132,8 @@ class Delivery_Day extends Base {
 		}
 
 		$non_standard_fees                       = Base::non_standard_fees_data();
+		$chosen_rate_cost                        = Utils::get_chosen_shipping_rate_cost();
+		$is_free_shipping                        = $chosen_rate_cost <= 0;
 		$return_data                             = $this->get_init_content_data( $post_data );
 		$show_delivery_days                      = $this->is_customer_allowed_to_pick_delivery_day();
 		$return_data['is_delivery_days_enabled'] = $show_delivery_days;
@@ -144,7 +146,7 @@ class Delivery_Day extends Base {
 			$options = array_map(
 				function ( $timeframe ) use ( $non_standard_fees, $is_free_shipping ) {
 					$type  = array_shift( $timeframe['Options'] );
-					$price = isset( $non_standard_fees[ $type ] ) ? $non_standard_fees[ $type ]['fee_price'] : 0;
+					$price = isset( $non_standard_fees[ $type ] ) && ! $is_free_shipping ? $non_standard_fees[ $type ]['fee_price'] : 0;
 
 					return array(
 						'from'            => Utils::get_hour_min( $timeframe['From'] ),

--- a/src/Frontend/Delivery_Day.php
+++ b/src/Frontend/Delivery_Day.php
@@ -142,7 +142,7 @@ class Delivery_Day extends Base {
 			}
 
 			$options = array_map(
-				function ( $timeframe ) use ( $non_standard_fees ) {
+				function ( $timeframe ) use ( $non_standard_fees, $is_free_shipping ) {
 					$type  = array_shift( $timeframe['Options'] );
 					$price = isset( $non_standard_fees[ $type ] ) ? $non_standard_fees[ $type ]['fee_price'] : 0;
 

--- a/src/Frontend/Delivery_Day.php
+++ b/src/Frontend/Delivery_Day.php
@@ -153,6 +153,7 @@ class Delivery_Day extends Base {
 						'to'              => Utils::get_hour_min( $timeframe['To'] ),
 						'type'            => $type,
 						'price'           => $price,
+						'price_display'   => Utils::get_fee_total_price( $price ),
 						'price_formatted' => Utils::get_formatted_fee_total_price( $price ),
 					);
 				},

--- a/src/Shipping_Method/PostNL.php
+++ b/src/Shipping_Method/PostNL.php
@@ -76,9 +76,9 @@ class PostNL extends \WC_Shipping_Flat_Rate {
 	 * @param array $package Package of items from cart.
 	 */
 	public function calculate_shipping( $package = array() ) {
-		// Set free shipping rate if cart subtotal exceed minimum_for_free_shipping
+		// Set free shipping rate if cart subtotal exceed minimum_for_free_shipping.
 		$minimum_for_free_shipping = $this->get_option( 'minimum_for_free_shipping' );
-		if ( '' !== $minimum_for_free_shipping && $package['cart_subtotal'] > $minimum_for_free_shipping ) {
+		if ( '' !== $minimum_for_free_shipping && $package['cart_subtotal'] >= $minimum_for_free_shipping ) {
 			$rate = array(
 				'id'      => $this->get_rate_id(),
 				'label'   => $this->title,

--- a/src/Shipping_Method/PostNL.php
+++ b/src/Shipping_Method/PostNL.php
@@ -76,7 +76,7 @@ class PostNL extends \WC_Shipping_Flat_Rate {
 	 * @param array $package Package of items from cart.
 	 */
 	public function calculate_shipping( $package = array() ) {
-		// Set free shipping rate if cart subtotal exceed minimum_for_free_shipping.
+		// Set free shipping rate if cart subtotal meets or exceeds minimum_for_free_shipping.
 		$minimum_for_free_shipping = $this->get_option( 'minimum_for_free_shipping' );
 		if ( '' !== $minimum_for_free_shipping && $package['cart_subtotal'] >= $minimum_for_free_shipping ) {
 			$rate = array(

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1045,15 +1045,13 @@ class Utils {
 	}
 
 	/**
-	 * Get the base cost (excl. tax) of the chosen PostNL shipping rate,
-	 * with any previously-injected PostNL option fee removed.
+	 * Get the cost of the currently chosen shipping rate (any method).
+	 * Returns the rate cost as stored in the package rates (after woocommerce_package_rates
+	 * filters have run, i.e. including any injected PostNL tab fees).
 	 *
-	 * @param float $delivery_day_fee The delivery-day additional fee configured in settings.
-	 * @param float $pickup_fee       The pickup additional fee configured in settings.
-	 *
-	 * @return float Base shipping cost excluding tax, or 0.0 if unavailable.
+	 * @return float
 	 */
-	public static function get_chosen_postnl_base_rate_cost(): float {
+	public static function get_chosen_shipping_rate_cost(): float {
 		if ( is_null( WC()->cart ) || is_null( WC()->session ) ) {
 			return 0.0;
 		}
@@ -1072,15 +1070,7 @@ class Utils {
 				continue;
 			}
 
-			/** @var \WC_Shipping_Rate $rate */
-			$rate = $package['rates'][ $chosen_key ];
-
-			if ( POSTNL_SETTINGS_ID !== $rate->get_method_id() ) {
-				continue;
-			}
-
-			// Return the shipping rate cost directly — no extra has been injected.
-			return max( 0.0, (float) $rate->get_cost() );
+			return max( 0.0, (float) $package['rates'][ $chosen_key ]->cost );
 		}
 
 		return 0.0;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1052,6 +1052,11 @@ class Utils {
 	 * @return float
 	 */
 	public static function get_chosen_shipping_rate_cost(): float {
+		static $cached = null;
+		if ( null !== $cached ) {
+			return $cached;
+		}
+
 		if ( is_null( WC()->cart ) || is_null( WC()->session ) ) {
 			return 0.0;
 		}
@@ -1078,7 +1083,8 @@ class Utils {
 				continue;
 			}
 
-			return max( 0.0, (float) $package['rates'][ $chosen_key ]->cost );
+			$cached = max( 0.0, (float) $package['rates'][ $chosen_key ]->cost );
+			return $cached;
 		}
 
 		return 0.0;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1063,6 +1063,14 @@ class Utils {
 
 		$packages = WC()->shipping()->get_packages();
 
+		// In block checkout, the Store API calculates shipping via a different
+		// code path that doesn't populate WC_Shipping::$packages. Fall back to
+		// calculating from the cart's raw packages when the result is empty.
+		if ( empty( $packages ) && ! WC()->cart->is_empty() ) {
+			$raw_packages = WC()->cart->get_shipping_packages();
+			$packages     = WC()->shipping()->calculate_shipping( $raw_packages );
+		}
+
 		foreach ( $packages as $i => $package ) {
 			$chosen_key = $chosen_methods[ $i ] ?? '';
 

--- a/templates/checkout/postnl-container.php
+++ b/templates/checkout/postnl-container.php
@@ -48,6 +48,18 @@ $field = array_shift( $fields );
 									);
 									?>
 									"
+									data-total-formatted="
+									<?php
+									echo esc_attr(
+										'delivery_day' === $field_tab['id']
+											? ( isset( $delivery_day_total_formatted ) ? $delivery_day_total_formatted : '' )
+											: ( 'dropoff_points' === $field_tab['id']
+											? ( isset( $pickup_total_formatted ) ? $pickup_total_formatted : '' )
+											: ''
+										)
+									);
+									?>
+									"
 							>
 
 								<span>

--- a/templates/checkout/postnl-container.php
+++ b/templates/checkout/postnl-container.php
@@ -33,16 +33,33 @@ $field = array_shift( $fields );
 						?>
 
 						<li class="<?php echo esc_attr( $active_class ); ?>">
-							<label
-									for="<?php echo esc_attr( $field['name'] . '_' . $field_tab['id'] ); ?>"
-									class="postnl_checkout_tab"
-									data-base-fee="
-									<?php
-									echo esc_attr(
-										'delivery_day' === $field_tab['id']
-											? (float) $delivery_day_fee
-											: ( 'dropoff_points' === $field_tab['id']
-											? (float) $pickup_fee
+<?php
+					$_tab_carrier_base = isset( $carrier_base ) ? (float) $carrier_base : 0.0;
+					$_dd_total_numeric = $_tab_carrier_base + (float) $delivery_day_fee;
+					$_pu_total_numeric = $_tab_carrier_base + (float) $pickup_fee;
+					?>
+					<label
+							for="<?php echo esc_attr( $field['name'] . '_' . $field_tab['id'] ); ?>"
+							class="postnl_checkout_tab"
+							data-base-fee="
+							<?php
+							echo esc_attr(
+								'delivery_day' === $field_tab['id']
+									? (float) $delivery_day_fee
+									: ( 'dropoff_points' === $field_tab['id']
+									? (float) $pickup_fee
+									: 0
+								)
+							);
+							?>
+							"
+							data-total-numeric="
+							<?php
+							echo esc_attr(
+								'delivery_day' === $field_tab['id']
+									? $_dd_total_numeric
+									: ( 'dropoff_points' === $field_tab['id']
+									? $_pu_total_numeric
 											: 0
 										)
 									);
@@ -65,12 +82,12 @@ $field = array_shift( $fields );
 								<span>
 									<?php
 									echo esc_html( $field_tab['name'] );
-									if ( 'delivery_day' === $field_tab['id'] && ! empty( $delivery_day_fee ) && $delivery_day_fee > 0 ) {
-										$total = ! empty( $delivery_day_total_formatted ) ? $delivery_day_total_formatted : Utils::get_formatted_fee_total_price( $delivery_day_fee );
-										printf( ' (%s)', esc_html( $total ) );
-									}
-									if ( 'dropoff_points' === $field_tab['id'] && ! empty( $pickup_fee ) && $pickup_fee > 0 ) {
-										$total = ! empty( $pickup_total_formatted ) ? $pickup_total_formatted : Utils::get_formatted_fee_total_price( $pickup_fee );
+								if ( 'delivery_day' === $field_tab['id'] && $_dd_total_numeric > 0 ) {
+									$total = ! empty( $delivery_day_total_formatted ) ? $delivery_day_total_formatted : Utils::get_formatted_fee_total_price( $_dd_total_numeric );
+									printf( ' (%s)', esc_html( $total ) );
+								}
+								if ( 'dropoff_points' === $field_tab['id'] && $_pu_total_numeric > 0 ) {
+									$total = ! empty( $pickup_total_formatted ) ? $pickup_total_formatted : Utils::get_formatted_fee_total_price( $_pu_total_numeric );
 										printf( ' (%s)', esc_html( $total ) );
 									}
 									?>

--- a/templates/checkout/postnl-container.php
+++ b/templates/checkout/postnl-container.php
@@ -65,11 +65,13 @@ $field = array_shift( $fields );
 								<span>
 									<?php
 									echo esc_html( $field_tab['name'] );
-									if ( 'dropoff_points' === $field_tab['id'] && ! empty( $pickup_fee ) && $pickup_fee > 0 ) {
-										printf( ' (+%s)', Utils::get_formatted_fee_total_price( $pickup_fee ) );
-									}
 									if ( 'delivery_day' === $field_tab['id'] && ! empty( $delivery_day_fee ) && $delivery_day_fee > 0 ) {
-										printf( ' (+%s)', Utils::get_formatted_fee_total_price( $delivery_day_fee ) );
+										$total = ! empty( $delivery_day_total_formatted ) ? $delivery_day_total_formatted : Utils::get_formatted_fee_total_price( $delivery_day_fee );
+										printf( ' (%s)', esc_html( $total ) );
+									}
+									if ( 'dropoff_points' === $field_tab['id'] && ! empty( $pickup_fee ) && $pickup_fee > 0 ) {
+										$total = ! empty( $pickup_total_formatted ) ? $pickup_total_formatted : Utils::get_formatted_fee_total_price( $pickup_fee );
+										printf( ' (%s)', esc_html( $total ) );
 									}
 									?>
 								</span>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
[Task url](https://app.clickup.com/t/868hh4q93)
### How to test the changes in this Pull Request:

1. Add a product that is **not eligible for ALA** to the cart.
2. Go to the checkout page and verify the **Delivery Days** and **Pickup Points** tabs. The displayed fees should match the **selected shipping method total** (shipping method rate + tab fees), plus **tax** if tax is included.
3. Confirm that **method fees**, **tab fees**, and **morning fees** become **free when the order total exceeds the free shipping threshold**.
4. Perform these tests on **both Shortcode Checkout and Blocks Checkout**.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
