### PR TITLE
add letterbox fee for ALA

### DIFF
--- a/src/Checkout_Blocks/Extend_Block_Core.php
+++ b/src/Checkout_Blocks/Extend_Block_Core.php
@@ -170,8 +170,12 @@ class Extend_Block_Core {
 			return $rates;
 		}
 
-		$session_type = WC()->session->get( 'postnl_delivery_type', '' );
-		if ( '' === $session_type ) {
+		$letterbox     = Utils::is_cart_eligible_auto_letterbox( WC()->cart );
+		$letterbox_fee = $this->settings->get_letterbox_fee();
+		$session_type  = WC()->session->get( 'postnl_delivery_type', '' );
+
+		// Nothing to do when letterbox is not active and no delivery type has been chosen.
+		if ( ! $letterbox && '' === $session_type ) {
 			return $rates;
 		}
 
@@ -191,20 +195,28 @@ class Extend_Block_Core {
 				continue;
 			}
 
-			$extra = 0;
+			if ( $letterbox && null !== $letterbox_fee ) {
+				// Replace the entire shipping cost with the configured letterbox fee.
+				$rate->cost = $letterbox_fee;
+			} elseif ( '' !== $session_type ) {
+				$extra = 0;
 
-			if ( 'Pickup' === $session_type && $pickup_fee > 0 ) {
-				$extra = $pickup_fee;
-			} elseif ( 'Pickup' !== $session_type ) {
-				// Fold both the tab base fee and any morning/evening extra fee into the rate.
-				$extra = $base_day_fee + (float) WC()->session->get( 'postnl_delivery_fee', 0 );
-			}
+				if ( 'Pickup' === $session_type && $pickup_fee > 0 ) {
+					$extra = $pickup_fee;
+				} elseif ( 'Pickup' !== $session_type ) {
+					// Fold both the tab base fee and any morning/evening extra fee into the rate.
+					$extra = $base_day_fee + (float) WC()->session->get( 'postnl_delivery_fee', 0 );
+				}
 
-			if ( $extra <= 0 ) {
+				if ( $extra <= 0 ) {
+					continue;
+				}
+
+				$rate->cost += $extra;
+			} else {
+				// Letterbox active but no fee configured — leave rate unchanged.
 				continue;
 			}
-
-			$rate->cost += $extra;
 
 			if ( wc_tax_enabled() && 'taxable' === $rate->get_tax_status() ) {
 				$tax_rates   = \WC_Tax::get_shipping_tax_rates();

--- a/src/Frontend/Container.php
+++ b/src/Frontend/Container.php
@@ -551,9 +551,12 @@ class Container {
 			return $rates;
 		}
 
-		$option = $package['destination']['postnl_option'] ?? WC()->session->get( 'postnl_option', '' );
+		$option        = $package['destination']['postnl_option'] ?? WC()->session->get( 'postnl_option', '' );
+		$letterbox     = Utils::is_cart_eligible_auto_letterbox( \WC()->cart );
+		$letterbox_fee = $this->settings->get_letterbox_fee();
 
-		if ( '' === $option ) {
+		// Nothing to do when letterbox is not active and no option has been selected.
+		if ( ! $letterbox && '' === $option ) {
 			return $rates;
 		}
 
@@ -572,23 +575,31 @@ class Container {
 				continue;
 			}
 
-			$extra = 0;
-			if ( 'dropoff_points' === $option && $pickup_fee > 0 ) {
-				$extra = $pickup_fee;
-			} elseif ( 'delivery_day' === $option ) {
-				// Fold both the tab base fee and any morning/evening extra fee into the rate.
-				// Prefer the package destination value (set by add_postnl_option_to_package during
-				// AJAX calls) and fall back to the session value for order placement, when
-				// $_REQUEST['post_data'] is no longer available.
-				$extra  = $base_day_fee;
-				$extra += (float) ( $package['destination']['postnl_delivery_day_price'] ?? WC()->session->get( 'postnl_delivery_day_price', 0 ) );
-			}
+			if ( $letterbox && null !== $letterbox_fee ) {
+				// Replace the entire shipping cost with the configured letterbox fee.
+				$rate->cost = $letterbox_fee;
+			} elseif ( '' !== $option ) {
+				$extra = 0;
+				if ( 'dropoff_points' === $option && $pickup_fee > 0 ) {
+					$extra = $pickup_fee;
+				} elseif ( 'delivery_day' === $option ) {
+					// Fold both the tab base fee and any morning/evening extra fee into the rate.
+					// Prefer the package destination value (set by add_postnl_option_to_package during
+					// AJAX calls) and fall back to the session value for order placement, when
+					// $_REQUEST['post_data'] is no longer available.
+					$extra  = $base_day_fee;
+					$extra += (float) ( $package['destination']['postnl_delivery_day_price'] ?? WC()->session->get( 'postnl_delivery_day_price', 0 ) );
+				}
 
-			if ( $extra <= 0 ) {
+				if ( $extra <= 0 ) {
+					continue;
+				}
+
+				$rate->cost += $extra;
+			} else {
+				// Letterbox active but no fee configured — leave rate unchanged.
 				continue;
 			}
-
-			$rate->cost += $extra;
 
 			if ( wc_tax_enabled() && 'taxable' === $rate->get_tax_status() ) {
 				$tax_rates   = \WC_Tax::get_shipping_tax_rates();

--- a/src/Shipping_Method/Settings.php
+++ b/src/Shipping_Method/Settings.php
@@ -341,6 +341,14 @@ class Settings extends \WC_Settings_API {
 				'for_country' => array( 'NL', 'BE' ),
 				'class'       => 'wc_input_price country-nl country-be',
 			),
+			'letterbox_fee'                   => array(
+				'title'       => __( 'Letterbox fee', 'postnl-for-woocommerce' ),
+				'type'        => 'price',
+				'description' => __( 'Overrides the shipping cost when all items are eligible for letterbox delivery. Leave empty to use the standard shipping cost. The fee is set to €0 when free shipping applies.', 'postnl-for-woocommerce' ),
+				'desc_tip'    => true,
+				'for_country' => array( 'NL' ),
+				'class'       => 'wc_input_price country-nl',
+			),
 			'number_delivery_days'            => array(
 				'title'             => __( 'Number of Delivery Days', 'postnl-for-woocommerce' ),
 				'type'              => 'number',
@@ -1125,6 +1133,17 @@ class Settings extends \WC_Settings_API {
 	 */
 	public function get_delivery_days_fee() {
 		return (float) $this->get_country_option( 'delivery_days_fee' );
+	}
+
+	/**
+	 * Get letterbox fee from the settings.
+	 * Returns null when the field is empty (meaning: do not override).
+	 *
+	 * @return float|null
+	 */
+	public function get_letterbox_fee() {
+		$value = $this->get_country_option( 'letterbox_fee' );
+		return ( '' !== $value ) ? (float) $value : null;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

Adds a new "Letterbox fee" / "Verzendkosten brievenbuspakje" config field (NL only, up to 2 decimals). When ALA (Auto-LetterboxParcel) triggers — i.e. the cart is letterbox-eligible — the configured letterbox fee **replaces** the active shipping method's cost on both the Blocks and Classic checkouts. When the field is empty, the regular shipping method fee is used (no override). When free shipping applies (free shipping method or option threshold), the letterbox fee is bypassed and the shipping cost stays at €0.

Branch was rebased onto `main` to apply cleanly on top of the recent fee-calculation refactor (`#306`, `#310`) — the duplicated `$extra` calculation that existed on the original branch has been dropped in favor of `main`'s improved version that folds the morning/evening session fee and the package-destination `postnl_delivery_day_price` into the rate.

[Task url](https://app.clickup.com/t/868hh5u30)

### How to test the changes in this Pull Request:

**Setup**
1. Enable a PostNL-supported NL shipping method with a non-zero cost (e.g. €5.00).
2. Open *WooCommerce → Settings → Shipping → PostNL* and confirm the new **Letterbox fee** field appears (NL section). Set it to `2.00`.
3. Have one product configured to be letterbox-eligible (small/light enough to satisfy `is_cart_eligible_auto_letterbox`) and one that isn't.

**Core behavior — letterbox fee replaces cost**
4. As both **guest** and **logged-in** customer, on **both Blocks and Classic** checkout, add only the letterbox-eligible product. The PostNL shipping rate should show **€2.00**, not €5.00. Place the order and confirm the saved shipping total is €2.00.

**Empty fee falls back**
5. Clear the Letterbox fee field (leave empty). Repeat step 4 — the rate should show the unmodified shipping method fee (**€5.00**).

**Free shipping wins**
6. With Letterbox fee set to €2.00, add a coupon or set the cart total above the free-shipping threshold so the rate's cost arrives as €0. The shipping rate should remain **€0.00** (the letterbox fee must not override free shipping).
7. Switch the active shipping method to *Free Shipping*. Confirm the rate stays free regardless of the Letterbox fee setting.

**Non-letterbox cart still uses main's fee logic**
8. Add the non-letterbox-eligible product (or a mix that disqualifies ALA). Confirm:
   - **Pickup / dropoff_points** option adds `pickup_delivery_fee` to the rate.
   - **delivery_day** option adds `delivery_days_fee` plus the package-destination `postnl_delivery_day_price` (morning/evening surcharge).
   - These behaviors must be unchanged from `main` — the letterbox path should not affect them.

**Regression check**
9. With Query Monitor active, complete a checkout on each path (Blocks + Classic, guest + logged-in) and verify no PHP notices/warnings, and that the order's shipping line item, totals, and tax (if `wc_tax_enabled`) are correct.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Add - "Letterbox fee" setting (NL) that overrides the PostNL shipping cost when the cart qualifies for auto-letterbox; falls back to the regular shipping method fee when empty and is bypassed when free shipping applies.
