### PR TITLE
Fix multicollo error for insured domestic shipments

### DIFF
--- a/src/Rest_API/Shipping/Client.php
+++ b/src/Rest_API/Shipping/Client.php
@@ -157,14 +157,6 @@ class Client extends Base {
 			$shipment['ReturnBarcode'] = $this->item_info->shipment['main_barcode'];
 		}
 
-		if ( $this->item_info->backend_data['insured_shipping'] ) {
-			$shipment['Amounts'][] = array(
-				'AmountType' => '02',
-				'Currency'   => $this->item_info->shipment['currency'],
-				'Value'      => $this->item_info->shipment['subtotal'],
-			);
-		}
-
 		for ( $i = 1; $i <= $this->item_info->backend_data['num_labels']; $i++ ) {
 			if ( $this->item_info->backend_data['num_labels'] > 1 ) {
 				$shipment['Barcode'] = $this->item_info->shipment['barcodes'][ ( $i - 1 ) ];
@@ -177,6 +169,23 @@ class Client extends Base {
 					),
 				);
 			}
+
+			// Amounts (insurance) must only be present on the first/parent shipment.
+			// Unset it for child shipments to avoid the "child shipment cannot contain an insurance amount" error.
+			if ( $this->item_info->backend_data['insured_shipping'] ) {
+				if ( 1 === $i ) {
+					$shipment['Amounts'] = array(
+						array(
+							'AmountType' => '02',
+							'Currency'   => $this->item_info->shipment['currency'],
+							'Value'      => $this->item_info->shipment['subtotal'],
+						),
+					);
+				} else {
+					unset( $shipment['Amounts'] );
+				}
+			}
+
 			$shipments[] = $shipment;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
[Task url](https://app.clickup.com/t/868hn6xpq)
### How to test the changes in this Pull Request:

1. Set the default domestic shipping option to **Insured Shipping**.
2. Create a new **domestic order**.
3. Open the created order and edit it.
4. Change the **Number of Labels** to **2**.
5. Generate the shipping label.
6. Verify that the label is generated successfully without any errors.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
