### PR TITLE
fix ZPL file format setting ignored for domestic letterbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.9.5
 * Fix: Update translations.
+* Fix: ZPL file format setting ignored for domestic letterbox.
 
 ### 5.9.4
 * Fix: Missing styles from the cart page.

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,8 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.9.5 (2026-xx-xx) =
 * Fix: Update translations.
+* Fix: ZPL file format setting ignored for domestic letterbox.
+
 
 = 5.9.4 (2026-02-06) =
 * Fix: Missing styles from the cart page.

--- a/src/Rest_API/Shipping/Item_Info.php
+++ b/src/Rest_API/Shipping/Item_Info.php
@@ -479,7 +479,7 @@ class Item_Info extends Base_Info {
 			'printer_type'            => array(
 				'default'  => $this->get_product_code() == '4909' ? 'GraphicFile|PDF' : $this->settings->get_printer_type(),
 				'sanitize' => function ( $value ) use ( $self ) {
-					if ( in_array( $this->get_product_code(), array( '4909', '2928' ) ) ) {
+					if ( in_array( $this->get_product_code(), array( '4909' ) ) ) {
 						return 'GraphicFile|PDF';
 					}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
[Task url](https://app.clickup.com/t/868hkznjf)

### How to test the changes in this Pull Request:

1. Select ZPL for printer type
2. Create domestic letterbox order
3. Generate label and confirm that it is a ZPL format

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
