### PR TITLE
Fix letterbox orders showing Standard Shipment as delivery type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.9.9
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
-* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
-* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 ### 5.9.8
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 ### 5.9.9
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 * Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
+* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 ### 5.9.8
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 5.9.9
+* Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+
 ### 5.9.8
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ### 5.9.9
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
 
 ### 5.9.8
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,6 @@
 
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
-* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
-* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 * Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
+* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** PostNL for WooCommerce ***
 
+= 5.9.9 (2026-xx-xx) =
+* Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.
 

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"license": "GPL-3.0",
 	"type": "wordpress-plugin",
 	"require": {
-		"clegginabox/pdf-merger": "dev-master",
-		"postnl/api-client-sdk": "1.x-dev@dev"
+		"php": ">=7.4",
+		"clegginabox/pdf-merger": "dev-master"
 	},
 	"autoload": {
 		"psr-4": {
@@ -49,6 +49,7 @@
 		]
 	},
 	"require-dev": {
+		"postnl/api-client-sdk": "dev-main#5a064dd",
 		"wp-cli/i18n-command": "^2.6",
 		"squizlabs/php_codesniffer": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
@@ -56,7 +57,9 @@
 		"woocommerce/woocommerce-sniffs": "*",
 		"phpunit/phpunit": "^10.5",
 		"yoast/phpunit-polyfills": "^2.0",
-		"brain/monkey": "^2.6"
+		"brain/monkey": "^2.6",
+		"guzzlehttp/guzzle": "^7.11",
+		"league/oauth2-client": "^2.9"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00f79e7a826946d48ffecd02658b0716",
+    "content-hash": "406b01d6c34e0be97217ff56906cf672",
     "packages": [
         {
             "name": "clegginabox/pdf-merger",
@@ -46,967 +46,6 @@
                 "source": "https://github.com/clegginabox/pdf-merger/tree/master"
             },
             "time": "2024-06-21T04:59:28+00:00"
-        },
-        {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c987f8ce84b8434fa430795eca0f3430663da72b",
-                "reference": "c987f8ce84b8434fa430795eca0f3430663da72b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
-            },
-            "provide": {
-                "psr/http-client-implementation": "1.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.4",
-                "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
-                "psr/log": "^1.1 || ^2.0 || ^3.0"
-            },
-            "suggest": {
-                "ext-curl": "Required for CURL handler support",
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Jeremy Lindblom",
-                    "email": "jeremeamia@gmail.com",
-                    "homepage": "https://github.com/jeremeamia"
-                },
-                {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "psr-18",
-                "psr-7",
-                "rest",
-                "web service"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-02T12:40:51+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-02T12:23:43+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5 || ^8.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
-            },
-            "provide": {
-                "psr/http-factory-implementation": "1.0",
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "1.1.0",
-                "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
-            },
-            "suggest": {
-                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
-                    "homepage": "https://github.com/Tobion"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-02T12:30:48+00:00"
-        },
-        {
-            "name": "league/oauth2-client",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/oauth2-client.git",
-                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
-                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
-                "php": "^7.1 || >=8.0.0 <8.6.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.3.5",
-                "php-parallel-lint/php-parallel-lint": "^1.4",
-                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
-                "squizlabs/php_codesniffer": "^3.11"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "League\\OAuth2\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alex Bilbie",
-                    "email": "hello@alexbilbie.com",
-                    "homepage": "http://www.alexbilbie.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Woody Gilk",
-                    "homepage": "https://github.com/shadowhand",
-                    "role": "Contributor"
-                }
-            ],
-            "description": "OAuth 2.0 Client Library",
-            "keywords": [
-                "Authentication",
-                "SSO",
-                "authorization",
-                "identity",
-                "idp",
-                "oauth",
-                "oauth2",
-                "single sign on"
-            ],
-            "support": {
-                "issues": "https://github.com/thephpleague/oauth2-client/issues",
-                "source": "https://github.com/thephpleague/oauth2-client/tree/2.9.0"
-            },
-            "time": "2025-11-25T22:17:17+00:00"
-        },
-        {
-            "name": "php-http/discovery",
-            "version": "1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/discovery.git",
-                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
-                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0|^2.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "nyholm/psr7": "<1.0",
-                "zendframework/zend-diactoros": "*"
-            },
-            "provide": {
-                "php-http/async-client-implementation": "*",
-                "php-http/client-implementation": "*",
-                "psr/http-client-implementation": "*",
-                "psr/http-factory-implementation": "*",
-                "psr/http-message-implementation": "*"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0.2|^2.0",
-                "graham-campbell/phpspec-skip-example-extension": "^5.0",
-                "php-http/httplug": "^1.0 || ^2.0",
-                "php-http/message-factory": "^1.0",
-                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
-                "sebastian/comparator": "^3.0.5 || ^4.0.8",
-                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Http\\Discovery\\Composer\\Plugin",
-                "plugin-optional": true
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Discovery\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/Composer/Plugin.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "adapter",
-                "client",
-                "discovery",
-                "factory",
-                "http",
-                "message",
-                "psr17",
-                "psr7"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.20.0"
-            },
-            "time": "2024-10-02T11:20:13+00:00"
-        },
-        {
-            "name": "postnl/api-client-sdk",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:Postnl-Production/api-client-sdk.git",
-                "reference": "5a064dd931b319f47861cc2ef544ad7b962b95a7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Postnl-Production/api-client-sdk/zipball/5a064dd931b319f47861cc2ef544ad7b962b95a7",
-                "reference": "5a064dd931b319f47861cc2ef544ad7b962b95a7",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://postnl.repo.packagist.com/progressus/dists/%package%/%version%/r%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "league/oauth2-client": "^2.9",
-                "php": ">=8.2 <8.5",
-                "php-http/discovery": "^1.17",
-                "psr/http-client": "^1.0",
-                "psr/http-client-implementation": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-factory-implementation": "^1.0",
-                "psr/http-message": "^2.0",
-                "psr/log": "^3.0",
-                "psr/simple-cache": "^3.0"
-            },
-            "require-dev": {
-                "cebe/php-openapi": "^1.7",
-                "fakerphp/faker": "^1.24",
-                "friendsofphp/php-cs-fixer": "^3.93.1",
-                "guzzlehttp/guzzle": "^7.12.1",
-                "phpstan/phpstan": "^1.11",
-                "phpunit/phpunit": "^10.5.63",
-                "rector/rector": "^1.2",
-                "symfony/process": "^7.4.5",
-                "symfony/yaml": "^7.4.12"
-            },
-            "suggest": {
-                "ext-redis": "Required for Redis cache backend (phpredis extension)",
-                "guzzlehttp/guzzle": "^7.12.1 - For convenient HTTP client when using withGuzzleOptions()"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Postnl\\Sdk\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Tests\\Unit\\": "tests/Unit",
-                    "Tests\\Feature\\": "tests/Feature",
-                    "Tests\\Support\\": "tests/Support",
-                    "Tests\\E2E\\": "tests/E2E",
-                    "Tests\\SchemaValidation\\": "tests/SchemaValidation",
-                    "Tests\\Integration\\": "tests/Integration",
-                    "Postnl\\Sdk\\PHPStan\\": "phpstan/",
-                    "Scripts\\": "scripts/"
-                }
-            },
-            "notification-url": "https://postnl.repo.packagist.com/progressus/downloads/",
-            "scripts": {
-                "lint:composer": [
-                    "composer validate --strict"
-                ],
-                "security:audit": [
-                    "composer audit --locked"
-                ],
-                "lint:cs": [
-                    "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff"
-                ],
-                "lint:stan": [
-                    "vendor/bin/phpstan analyse --configuration=phpstan.neon"
-                ],
-                "lint:rector": [
-                    "vendor/bin/rector process --config=rector.php --dry-run"
-                ],
-                "test:unit": [
-                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=CoreTests --no-coverage --display-warnings"
-                ],
-                "test:coverage": [
-                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=CoreTests"
-                ],
-                "test:coverage:check": [
-                    "@test:coverage",
-                    "php scripts/check-coverage.php"
-                ],
-                "test:integration": [
-                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=Integration --no-coverage --display-warnings"
-                ],
-                "test:e2e": [
-                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=e2e --no-coverage --testdox --display-warnings"
-                ],
-                "test:schema": [
-                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=SchemaValidation --no-coverage  --display-warnings"
-                ],
-                "ci": [
-                    "echo '🔎 Validating composer.json...'",
-                    "@lint:composer",
-                    "echo '🛡️  Auditing dependencies...'",
-                    "@security:audit",
-                    "echo '🎨 Checking code style (PHP CS Fixer)...'",
-                    "@lint:cs",
-                    "echo '🧠 Running static analysis (PHPStan)...'",
-                    "@lint:stan",
-                    "echo '🔧 Running Rector (automated refactoring check)...'",
-                    "@lint:rector",
-                    "echo '🧪 Running integration tests (PHPUnit)...'",
-                    "@test:integration",
-                    "echo '🧪 Running schema validation tests (PHPUnit)...'",
-                    "@test:schema",
-                    "echo '🧪 Running unit tests (PHPUnit)...'",
-                    "@test:unit"
-                ],
-                "ci:unit": [
-                    "echo '🔎 Validating composer.json...'",
-                    "@lint:composer",
-                    "echo '🛡️  Auditing dependencies...'",
-                    "@security:audit",
-                    "echo '🎨 Checking code style (PHP CS Fixer)...'",
-                    "@lint:cs",
-                    "echo '🧠 Running static analysis (PHPStan)...'",
-                    "@lint:stan",
-                    "echo '🔧 Running Rector (automated refactoring check)...'",
-                    "@lint:rector",
-                    "echo '🧪 Running unit tests (PHPUnit)...'",
-                    "@test:unit"
-                ],
-                "fix:cs": [
-                    "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
-                ],
-                "fix:rector": [
-                    "vendor/bin/rector process --config=rector.php"
-                ],
-                "fix": [
-                    "echo '🎨 Fixing code style issues (PHP CS Fixer)...'",
-                    "@fix:cs",
-                    "echo '🔧 Fixing Rector findings (automated refactoring check)...'",
-                    "@fix:rector"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PostNL SDK Team",
-                    "email": "postnl@example.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Official PHP SDK for PostNL APIs.",
-            "homepage": "https://github.com/Postnl-Production/api-client-sdk",
-            "keywords": [
-                "api",
-                "http-client",
-                "php",
-                "postnl",
-                "psr-12",
-                "psr-18",
-                "psr-3",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/Postnl-Production/api-client-sdk/issues",
-                "source": "https://github.com/Postnl-Production/api-client-sdk"
-            },
-            "time": "2026-06-05T15:06:44+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "setasign/fpdf",
@@ -1125,161 +164,6 @@
                 }
             ],
             "time": "2025-02-05T13:22:35+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-13T15:52:40+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
         }
     ],
     "packages-dev": [
@@ -1693,6 +577,337 @@
             "time": "2022-10-18T15:00:10+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-18T11:23:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-08T15:48:39+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-16T22:23:49+00:00"
+        },
+        {
             "name": "hamcrest/hamcrest-php",
             "version": "v2.1.1",
             "source": {
@@ -1742,6 +957,71 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "league/oauth2-client",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-client.git",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+                "php": "^7.1 || >=8.0.0 <8.6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "homepage": "https://github.com/shadowhand",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "OAuth 2.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth2",
+                "single sign on"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-client/issues",
+                "source": "https://github.com/thephpleague/oauth2-client/tree/2.9.0"
+            },
+            "time": "2025-11-25T22:17:17+00:00"
         },
         {
             "name": "mck89/peast",
@@ -2160,6 +1440,85 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2960,6 +2319,491 @@
                 }
             ],
             "time": "2026-01-27T05:48:37+00:00"
+        },
+        {
+            "name": "postnl/api-client-sdk",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:Postnl-Production/api-client-sdk.git",
+                "reference": "5a064dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Postnl-Production/api-client-sdk/zipball/5a064dd",
+                "reference": "5a064dd",
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://postnl.repo.packagist.com/progressus/dists/%package%/%version%/r%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2 <8.5",
+                "php-http/discovery": "^1.17",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message": "^2.0",
+                "psr/log": "^3.0",
+                "psr/simple-cache": "^3.0"
+            },
+            "require-dev": {
+                "cebe/php-openapi": "^1.7",
+                "fakerphp/faker": "^1.24",
+                "friendsofphp/php-cs-fixer": "^3.93.1",
+                "guzzlehttp/guzzle": "^7.12.1",
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^10.5.63",
+                "rector/rector": "^1.2",
+                "symfony/process": "^7.4.5",
+                "symfony/yaml": "^7.4.12"
+            },
+            "suggest": {
+                "ext-redis": "Required for Redis cache backend (phpredis extension)",
+                "guzzlehttp/guzzle": "^7.12.1 - For convenient HTTP client when using withGuzzleOptions()"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Postnl\\Sdk\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\Unit\\": "tests/Unit",
+                    "Tests\\Feature\\": "tests/Feature",
+                    "Tests\\Support\\": "tests/Support",
+                    "Tests\\E2E\\": "tests/E2E",
+                    "Tests\\SchemaValidation\\": "tests/SchemaValidation",
+                    "Tests\\Integration\\": "tests/Integration",
+                    "Postnl\\Sdk\\PHPStan\\": "phpstan/",
+                    "Scripts\\": "scripts/"
+                }
+            },
+            "notification-url": "https://postnl.repo.packagist.com/progressus/downloads/",
+            "scripts": {
+                "lint:composer": [
+                    "composer validate --strict"
+                ],
+                "security:audit": [
+                    "composer audit --locked"
+                ],
+                "lint:cs": [
+                    "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff"
+                ],
+                "lint:stan": [
+                    "vendor/bin/phpstan analyse --configuration=phpstan.neon"
+                ],
+                "lint:rector": [
+                    "vendor/bin/rector process --config=rector.php --dry-run"
+                ],
+                "test:unit": [
+                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=CoreTests --no-coverage --display-warnings"
+                ],
+                "test:coverage": [
+                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=CoreTests"
+                ],
+                "test:coverage:check": [
+                    "@test:coverage",
+                    "php scripts/check-coverage.php"
+                ],
+                "test:integration": [
+                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=Integration --no-coverage --display-warnings"
+                ],
+                "test:e2e": [
+                    "vendor/bin/phpunit --configuration=phpunit.e2e.xml --testsuite=e2e --no-coverage --testdox --display-warnings"
+                ],
+                "test:schema": [
+                    "vendor/bin/phpunit --configuration=phpunit.xml --testsuite=SchemaValidation --no-coverage  --display-warnings"
+                ],
+                "ci": [
+                    "echo '🔎 Validating composer.json...'",
+                    "@lint:composer",
+                    "echo '🛡️  Auditing dependencies...'",
+                    "@security:audit",
+                    "echo '🎨 Checking code style (PHP CS Fixer)...'",
+                    "@lint:cs",
+                    "echo '🧠 Running static analysis (PHPStan)...'",
+                    "@lint:stan",
+                    "echo '🔧 Running Rector (automated refactoring check)...'",
+                    "@lint:rector",
+                    "echo '🧪 Running integration tests (PHPUnit)...'",
+                    "@test:integration",
+                    "echo '🧪 Running schema validation tests (PHPUnit)...'",
+                    "@test:schema",
+                    "echo '🧪 Running unit tests (PHPUnit)...'",
+                    "@test:unit"
+                ],
+                "ci:unit": [
+                    "echo '🔎 Validating composer.json...'",
+                    "@lint:composer",
+                    "echo '🛡️  Auditing dependencies...'",
+                    "@security:audit",
+                    "echo '🎨 Checking code style (PHP CS Fixer)...'",
+                    "@lint:cs",
+                    "echo '🧠 Running static analysis (PHPStan)...'",
+                    "@lint:stan",
+                    "echo '🔧 Running Rector (automated refactoring check)...'",
+                    "@lint:rector",
+                    "echo '🧪 Running unit tests (PHPUnit)...'",
+                    "@test:unit"
+                ],
+                "fix:cs": [
+                    "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+                ],
+                "fix:rector": [
+                    "vendor/bin/rector process --config=rector.php"
+                ],
+                "fix": [
+                    "echo '🎨 Fixing code style issues (PHP CS Fixer)...'",
+                    "@fix:cs",
+                    "echo '🔧 Fixing Rector findings (automated refactoring check)...'",
+                    "@fix:rector"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PostNL SDK Team",
+                    "email": "postnl@example.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Official PHP SDK for PostNL APIs.",
+            "homepage": "https://github.com/Postnl-Production/api-client-sdk",
+            "keywords": [
+                "api",
+                "http-client",
+                "php",
+                "postnl",
+                "psr-12",
+                "psr-18",
+                "psr-3",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/Postnl-Production/api-client-sdk/issues",
+                "source": "https://github.com/Postnl-Production/api-client-sdk"
+            },
+            "time": "2026-07-20T06:58:40+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3999,6 +3843,77 @@
             "time": "2025-01-23T17:04:15+00:00"
         },
         {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
             "name": "symfony/finder",
             "version": "v7.2.2",
             "source": {
@@ -4061,6 +3976,90 @@
                 }
             ],
             "time": "2024-12-30T19:00:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4542,7 +4541,9 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/languages/postnl-for-woocommerce-nl_NL.po
+++ b/languages/postnl-for-woocommerce-nl_NL.po
@@ -39,14 +39,14 @@ msgid "https://postnl.post/"
 msgstr ""
 
 #: src/Checkout_Blocks/Extend_Block_Core.php:89
-#: src/Frontend/Container.php:489
+#: src/Frontend/Container.php:503
 msgid "This is not a valid address!"
 msgstr "Dit is geen geldig adres!"
 
 #: src/Checkout_Blocks/Extend_Block_Core.php:104
 #: src/Frontend/Checkout_Fields.php:65
 #: src/Frontend/Checkout_Fields.php:66
-#: src/Order/Single.php:539
+#: src/Order/Single.php:546
 msgid "House number"
 msgstr "Huisnummer"
 
@@ -75,12 +75,12 @@ msgid "Pick up at PostNL-point"
 msgstr "Ophalen bij PostNL-punt"
 
 #: src/Frontend/Base.php:171
-#: src/Order/Single.php:328
+#: src/Order/Single.php:335
 msgid "Date:"
 msgstr "Datum:"
 
 #: src/Frontend/Base.php:175
-#: src/Order/Single.php:332
+#: src/Order/Single.php:339
 msgid "Time:"
 msgstr "Tijd:"
 
@@ -112,11 +112,11 @@ msgstr "Straat"
 msgid "Street Name"
 msgstr "Straat"
 
-#: src/Frontend/Container.php:120
+#: src/Frontend/Container.php:138
 msgid "Delivery Days"
 msgstr "Bezorgdagen"
 
-#: src/Frontend/Container.php:121
+#: src/Frontend/Container.php:139
 #: src/Frontend/Dropoff_Points.php:52
 #: build/postnl-container-frontend.js:1
 #: client/checkout/postnl-container/block.js:283
@@ -175,48 +175,48 @@ msgstr ""
 msgid "Incomplete user data."
 msgstr ""
 
-#: src/Helper/Mapping.php:30
+#: src/Helper/Mapping.php:32
 #: src/Shipping_Method/Settings.php:372
 msgid "Morning Delivery"
 msgstr "Ochtend Bezorging"
 
-#: src/Helper/Mapping.php:31
+#: src/Helper/Mapping.php:33
 msgid "Standard Shipment"
 msgstr "Standaard Bezorging"
 
-#: src/Helper/Mapping.php:32
+#: src/Helper/Mapping.php:34
 #: src/Shipping_Method/Settings.php:390
 msgid "Evening Delivery"
 msgstr "Avondbezorging"
 
-#: src/Helper/Mapping.php:35
+#: src/Helper/Mapping.php:37
 msgid "Pickup at PostNL Point"
 msgstr "Ophalen bij PostNL Punt"
 
-#: src/Helper/Mapping.php:40
+#: src/Helper/Mapping.php:42
 #: src/Shipping_Method/Settings.php:642
-#: src/Utils.php:614
+#: src/Utils.php:622
 msgid "Standard Shipment Belgium"
 msgstr "Standaardzending België"
 
-#: src/Helper/Mapping.php:43
+#: src/Helper/Mapping.php:45
 msgid "Pickup at PostNL Point Belgium"
 msgstr "Ophalen bij PostNL België"
 
-#: src/Helper/Mapping.php:46
-#: src/Helper/Mapping.php:51
-#: src/Helper/Mapping.php:52
+#: src/Helper/Mapping.php:48
+#: src/Helper/Mapping.php:53
+#: src/Helper/Mapping.php:54
 #: src/Order/Bulk.php:518
 msgid "EU Parcel"
 msgstr "Europese zending"
 
-#: src/Helper/Mapping.php:47
-#: src/Helper/Mapping.php:53
+#: src/Helper/Mapping.php:49
+#: src/Helper/Mapping.php:55
 #: src/Order/Bulk.php:519
 msgid "Non-EU Shipment"
 msgstr "Non-EU bezorging"
 
-#: src/Helper/Mapping.php:50
+#: src/Helper/Mapping.php:52
 msgid "Belgium Domestic"
 msgstr "België binnenland"
 
@@ -240,124 +240,124 @@ msgstr "Laat een beoordeling achter"
 msgid "Settings"
 msgstr ""
 
-#: src/Order/Base.php:198
+#: src/Order/Base.php:242
 msgid "ID Check (18+): "
 msgstr "Leeftijdscheck (18+): "
 
-#: src/Order/Base.php:210
+#: src/Order/Base.php:254
 msgid "Insured Shipping: "
 msgstr "Verzekerd verzenden: "
 
-#: src/Order/Base.php:222
+#: src/Order/Base.php:266
 msgid "Insured Plus: "
 msgstr "Verzekerd Plus: "
 
-#: src/Order/Base.php:234
+#: src/Order/Base.php:278
 msgid "Return if no answer: "
 msgstr "Retour bij geen gehoor: "
 
-#: src/Order/Base.php:246
+#: src/Order/Base.php:290
 msgid "Signature on Delivery: "
 msgstr "Handtekening voor ontvangst: "
 
-#: src/Order/Base.php:258
+#: src/Order/Base.php:302
 msgid "Only Home Address: "
 msgstr "Alleen huisadres: "
 
-#: src/Order/Base.php:294
+#: src/Order/Base.php:338
 msgid "Packets: "
 msgstr "Pakje: "
 
-#: src/Order/Base.php:306
+#: src/Order/Base.php:350
 msgid "Mailbox Packet (International): "
 msgstr "Brievenbuspakje (Internationaal): "
 
-#: src/Order/Base.php:318
+#: src/Order/Base.php:362
 msgid "Track & Trace: "
 msgstr "Track & Trace: "
 
-#: src/Order/Base.php:330
+#: src/Order/Base.php:374
 msgid "Delivery code at the door: "
 msgstr "Bezorgcode aan de deur: "
 
-#: src/Order/Base.php:348
+#: src/Order/Base.php:392
 #: src/Order/Bulk.php:436
 msgid "Number of Labels: "
 msgstr "Aantal labels: "
 
-#: src/Order/Base.php:379
+#: src/Order/Base.php:423
 #: src/Order/Bulk.php:455
 msgid "Create Return Label: "
 msgstr "Creëer retourlabel: "
 
-#: src/Order/Base.php:394
+#: src/Order/Base.php:438
 #: src/Order/Bulk.php:467
 msgid "Start position printing label: "
 msgstr "Startpositie printen van labels "
 
-#: src/Order/Base.php:398
+#: src/Order/Base.php:442
 #: src/Order/Bulk.php:473
 msgid "Top Left"
 msgstr "Linksboven"
 
-#: src/Order/Base.php:399
+#: src/Order/Base.php:443
 #: src/Order/Bulk.php:474
 msgid "Top Right"
 msgstr "Rechtsboven"
 
-#: src/Order/Base.php:400
+#: src/Order/Base.php:444
 #: src/Order/Bulk.php:475
 msgid "Bottom Left"
 msgstr "Linksonder"
 
-#: src/Order/Base.php:401
+#: src/Order/Base.php:445
 #: src/Order/Bulk.php:476
 msgid "Bottom Right"
 msgstr "Rechtsonder"
 
-#: src/Order/Base.php:532
-#: src/Order/Base.php:725
-#: src/Order/Single.php:515
-#: src/Order/Single.php:620
-#: src/Order/Single.php:693
+#: src/Order/Base.php:576
+#: src/Order/Base.php:781
+#: src/Order/Single.php:522
+#: src/Order/Single.php:627
+#: src/Order/Single.php:698
 msgid "Order does not exist!"
 msgstr "Deze order bestaat niet!"
 
-#: src/Order/Base.php:822
+#: src/Order/Base.php:876
 msgid "Cannot create the barcode."
 msgstr "Kan geen barcode genereren."
 
-#: src/Order/Base.php:947
+#: src/Order/Base.php:999
 msgid "Cannot create return barcode."
 msgstr "Kan geen retourbarcode genereren."
 
-#: src/Order/Base.php:1140
+#: src/Order/Base.php:1192
 msgid "There are no files to merge."
 msgstr ""
 
-#: src/Order/Base.php:1144
+#: src/Order/Base.php:1196
 msgid "\"Imagick\" must be installed on the server to merge png files."
 msgstr ""
 
-#: src/Order/Base.php:1229
-#: src/Order/Base.php:1328
+#: src/Order/Base.php:1299
+#: src/Order/Base.php:1430
 msgid "Cannot create the label. Label content is missing"
 msgstr "Kan geen label creëren, label-inhoud ontbreekt"
 
-#: src/Order/Base.php:1260
+#: src/Order/Base.php:1346
 msgid "Cannot create the return label. Label content is missing"
 msgstr "Kan geen retourlabel creëren, label-inhoud ontbreekt"
 
-#: src/Order/Base.php:1291
+#: src/Order/Base.php:1393
 msgid "Cannot create the letterbox. Label content is missing"
 msgstr "Kan geen brievenbuspakje creëren, label-inhoud ontbreekt"
 
-#: src/Order/Base.php:1322
+#: src/Order/Base.php:1424
 msgid "Cannot create the label. Barcode data is missing"
 msgstr "Kan geen label creëren, barcode-informatie ontbreekt"
 
 #. translators: %s the current service.
-#: src/Order/Base.php:1457
+#: src/Order/Base.php:1559
 #, php-format
 msgid "%s Tracking Number: {tracking-link}"
 msgstr "%s Barcode: {tracking-link}"
@@ -465,98 +465,98 @@ msgstr "Verzendopties"
 msgid "Fits through letterbox"
 msgstr "Past door de brievenbus"
 
-#: src/Order/Single.php:135
+#: src/Order/Single.php:131
 msgid "Label & Tracking"
 msgstr "Label & Tracking"
 
-#: src/Order/Single.php:262
+#: src/Order/Single.php:267
 msgid "Delivery Type:"
 msgstr "Type bezorging:"
 
-#: src/Order/Single.php:293
+#: src/Order/Single.php:298
 msgid "Delivery Date:"
 msgstr "Bezorgdatum:"
 
-#: src/Order/Single.php:323
+#: src/Order/Single.php:330
 msgid "Pickup Address:"
 msgstr "Afhaaladres:"
 
-#: src/Order/Single.php:360
+#: src/Order/Single.php:367
 msgid "Activate return function"
 msgstr "Activeer retour functie"
 
-#: src/Order/Single.php:363
+#: src/Order/Single.php:370
 msgid "Return function is activated for this label"
 msgstr "Retour functie is geactiveerd voor dit label"
 
-#: src/Order/Single.php:366
+#: src/Order/Single.php:373
 msgid "Click here to activate the return function of this label"
 msgstr "Klik hier om de retour functie voor dit label te activeren"
 
-#: src/Order/Single.php:384
+#: src/Order/Single.php:391
 msgid "Send email with Smart Return"
 msgstr "Zend Smart Return email"
 
-#: src/Order/Single.php:422
+#: src/Order/Single.php:429
 msgid "Create Shipment"
 msgstr "Zending aanmaken"
 
-#: src/Order/Single.php:424
+#: src/Order/Single.php:431
 msgid "Print Label"
 msgstr "Print Label"
 
-#: src/Order/Single.php:426
+#: src/Order/Single.php:433
 msgid "Delete Label"
 msgstr "Verwijder Label"
 
-#: src/Order/Single.php:432
+#: src/Order/Single.php:439
 msgid "Print Return Label"
 msgstr "Retourlabel printen"
 
-#: src/Order/Single.php:437
+#: src/Order/Single.php:444
 msgid "Print Letterbox"
 msgstr "Label Brievenbuspakje printen"
 
-#: src/Order/Single.php:456
-#: src/Order/Single.php:501
-#: src/Order/Single.php:607
-#: src/Order/Single.php:680
+#: src/Order/Single.php:463
+#: src/Order/Single.php:508
+#: src/Order/Single.php:614
+#: src/Order/Single.php:685
 msgid "Cannot find nonce field!"
 msgstr "Kan nonce-veld niet vinden!"
 
-#: src/Order/Single.php:462
-#: src/Order/Single.php:507
+#: src/Order/Single.php:469
+#: src/Order/Single.php:514
 msgid "Nonce is invalid!"
 msgstr "Nonce is ongeldig!"
 
-#: src/Order/Single.php:612
-#: src/Order/Single.php:685
+#: src/Order/Single.php:619
+#: src/Order/Single.php:690
 msgid "Nonce is invalid"
 msgstr "Nonce is ongeldig"
 
-#: src/Order/Single.php:624
+#: src/Order/Single.php:631
 msgid "Already activated!"
 msgstr ""
 
-#: src/Order/Single.php:640
+#: src/Order/Single.php:645
 msgid "Unknown error."
 msgstr ""
 
 #. Translators: %s is the error message.
-#: src/Order/Single.php:664
+#: src/Order/Single.php:669
 #, php-format
 msgid "Error: %s"
 msgstr ""
 
-#: src/Order/Single.php:720
+#: src/Order/Single.php:723
 msgid "PrintcodeLabel could not found"
 msgstr ""
 
-#: src/Order/Single.php:751
+#: src/Order/Single.php:754
 msgid "Email could not be send"
 msgstr ""
 
-#: src/Order/Single.php:782
+#: src/Order/Single.php:785
 msgid "18+ Adults Only"
 msgstr ""
 
@@ -674,18 +674,18 @@ msgstr "Product ID bestaat niet!"
 msgid "“18+” and “Letterbox Parcel” cannot be enabled together. Letterbox has been disabled automatically."
 msgstr "“18+” en “Brievenbuspakje” kunnen niet samen worden ingeschakeld. Brievenbuspakje is automatisch uitgeschakeld."
 
-#: src/Rest_API/Barcode/Item_Info.php:66
-#: src/Rest_API/Shipping/Item_Info.php:140
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:66
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:140
 msgid "Order ID does not exist!"
 msgstr "Order ID bestaat niet!"
 
-#: src/Rest_API/Barcode/Item_Info.php:136
-#: src/Rest_API/Shipping/Item_Info.php:356
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:136
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:356
 msgid "Customer Code is empty!"
 msgstr "Klantcode is leeg!"
 
-#: src/Rest_API/Barcode/Item_Info.php:139
-#: src/Rest_API/Shipping/Item_Info.php:359
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:139
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:359
 msgid "Customer Number is empty!"
 msgstr "Klantnummer is leeg!"
 
@@ -710,8 +710,8 @@ msgid "Shipping \"City\" is empty!"
 msgstr "Plaats is een vereist veld!"
 
 #: src/Rest_API/Base_Info.php:182
-#: src/Rest_API/Checkout/Item_Info.php:260
-#: src/Rest_API/Postcode_Check/Item_Info.php:88
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:260
+#: src/Rest_API/Legacy/Postcode_Check/Item_Info.php:88
 msgid "Shipping \"Postcode\" is empty!"
 msgstr "Postcode  is een vereist veld!"
 
@@ -736,140 +736,140 @@ msgstr "Winkel postcode niet geconfigureerd!"
 msgid "Store country is not configured!"
 msgstr "Winkel land niet geconfigureerd!"
 
-#: src/Rest_API/Checkout/Item_Info.php:119
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:119
 msgid "Order date is empty!"
 msgstr "Geen orderdatum!"
 
-#: src/Rest_API/Checkout/Item_Info.php:123
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:123
 msgid "Shipping duration is empty!"
 msgstr "Geen overkomstduur ingesteld!"
 
-#: src/Rest_API/Checkout/Item_Info.php:131
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:131
 msgid "Wrong format for cut off time!"
 msgstr "Verkeerde format van Cut-off tijd ingesteld!"
 
-#: src/Rest_API/Checkout/Item_Info.php:215
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:215
 msgid "Locations value is not a number!"
 msgstr "Waarde is geen getal!"
 
-#: src/Rest_API/Postcode_Check/Item_Info.php:85
+#: src/Rest_API/Legacy/Postcode_Check/Item_Info.php:85
 msgid "Shipping \"House number\" is empty!"
 msgstr "Huisnummer is een vereist veld!"
 
-#: src/Rest_API/Shipment_and_Return/Item_Info.php:82
+#: src/Rest_API/Legacy/Shipment_and_Return/Item_Info.php:82
 msgid "Given id is not an Order"
 msgstr ""
 
-#: src/Rest_API/Shipment_and_Return/Item_Info.php:86
+#: src/Rest_API/Legacy/Shipment_and_Return/Item_Info.php:86
 msgid "Missing barcode"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:353
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:353
 msgid "Location Code is empty!"
 msgstr "Locatiecode niet ingevuld!"
 
-#: src/Rest_API/Shipping/Item_Info.php:368
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:368
 msgid "Store email is empty!"
 msgstr "Winkel e-mailadres niet geconfigureerd!"
 
-#: src/Rest_API/Shipping/Item_Info.php:374
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:374
 msgid "Wrong format for store email!"
 msgstr "Verkeerde format van e-mailadres!"
 
-#: src/Rest_API/Shipping/Item_Info.php:429
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:429
 msgid "Order ID is empty!"
 msgstr "Order ID is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:432
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:432
 msgid "Order number is empty!"
 msgstr "Ordernummer is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:435
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:435
 msgid "Barcode is empty!"
 msgstr "Barcode is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:447
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:447
 msgid "Product code is empty!"
 msgstr "Productcode is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:451
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:451
 msgid "Wrong format for product code!"
 msgstr "Verkeerde format voor productcode!"
 
-#: src/Rest_API/Shipping/Item_Info.php:496
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:496
 msgid "Total weight is empty!"
 msgstr "Totaal gewicht is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:511
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:511
 msgid "Customer email is not valid!"
 msgstr "Klant e-mailadres is ongeldig!"
 
-#: src/Rest_API/Shipping/Item_Info.php:541
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:541
 msgid "Delivery day \"Date\" is empty!"
 msgstr "Datum bezorgdag is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:557
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:557
 msgid "Delivery day \"From\" is empty!"
 msgstr "Bezorgdag “van” is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:570
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:570
 msgid "Delivery day \"To\" is empty!"
 msgstr "Bezorgdag “tot” is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:586
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:586
 msgid "Delivery day \"Type\" is empty!"
 msgstr "Bezorgdag “Type” is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:610
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:610
 msgid "Pickup \"Date\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:626
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:626
 msgid "Pickup \"Time\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:638
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:638
 msgid "Pickup \"Company name\" is empty!"
 msgstr "Afhaaladres winkelnaam is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:647
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:647
 msgid "Pickup \"Address 1\" is empty!"
 msgstr "Afhaaladres straatnaam/huisnummer zijn leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:662
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:662
 msgid "Pickup Point \"City\" is empty!"
 msgstr "Afhaaladres stad is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:671
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:671
 msgid "Pickup Point \"Postcode\" is empty!"
 msgstr "Afhaaladres postcode is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:683
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:683
 msgid "Pickup Point \"Country\" is empty!"
 msgstr "Afhaaladres land is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:817
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:817
 msgid "Item HS Code must be between 6 and 20 characters long"
 msgstr "HS Code moet tussen de 6 en 20 karakters lang zijn"
 
-#: src/Rest_API/Shipping/Item_Info.php:830
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:830
 msgid "Item \"Product ID\" is empty!"
 msgstr "Product ID is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:833
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:833
 msgid "Item \"Product SKU\" is empty!"
 msgstr "Product SKU is leeg!"
 
-#: src/Rest_API/Shipping/Item_Info.php:850
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:850
 msgid "Item quantity must be more than 1"
 msgstr "Hoeveelheid moet meer dan 1 zijn"
 
-#: src/Rest_API/Shipping/Item_Info.php:1096
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:1096
 msgid "Max weight for Mailbox Packet is 2kg!"
 msgstr "Het maximale gewicht van een brievenbuspakje is 2kg!"
 
 #. Translators: %s is the order total.
-#: src/Rest_API/Shipping/Item_Info.php:1119
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:1119
 #, php-format
 msgid "Insurance amount for EU shipments cannot exceed €5000. Your total is: %d"
 msgstr ""
@@ -1618,13 +1618,13 @@ msgid "Select a default shipping option for domestic orders that are shipped wit
 msgstr "Selecteer een standaard verzendoptie voor alle zendingen die binnen Nederland worden verstuurd met PostNL."
 
 #: src/Shipping_Method/Settings.php:617
-#: src/Utils.php:607
+#: src/Utils.php:615
 msgid "Standard shipment"
 msgstr "Standaardzending"
 
 #: src/Shipping_Method/Settings.php:618
 #: src/Shipping_Method/Settings.php:695
-#: src/Utils.php:608
+#: src/Utils.php:616
 msgid "ID Check (18+)"
 msgstr "ID Check (18+)"
 
@@ -1634,21 +1634,21 @@ msgid "ID Check (18+) + Insured Shipping"
 msgstr "ID Check (18+) + Verzekerd verzenden"
 
 #: src/Shipping_Method/Settings.php:621
-#: src/Utils.php:609
+#: src/Utils.php:617
 msgid "Return if no answer"
 msgstr "Retour bij geen gehoor"
 
 #: src/Shipping_Method/Settings.php:622
-#: src/Utils.php:610
+#: src/Utils.php:618
 msgid "Signature on Delivery"
 msgstr "Handtekening voor ontvangst"
 
 #: src/Shipping_Method/Settings.php:623
-#: src/Utils.php:611
+#: src/Utils.php:619
 msgid "Only Home Address"
 msgstr "Alleen huisadres"
 
-#: src/Utils.php:612
+#: src/Utils.php:620
 msgid "Letterbox"
 msgstr "Brievenbuspakje"
 
@@ -1703,7 +1703,7 @@ msgstr "Standaardzending België + Verzekerd Verzenden"
 #: src/Shipping_Method/Settings.php:646
 #: src/Shipping_Method/Settings.php:663
 #: src/Shipping_Method/Settings.php:680
-#: src/Utils.php:615
+#: src/Utils.php:623
 msgid "Boxable Packet"
 msgstr "Brievenbuspakje Internationaal"
 
@@ -1782,7 +1782,7 @@ msgid "Standard Shipping"
 msgstr "Standaardzending"
 
 #: src/Shipping_Method/Settings.php:696
-#: src/Utils.php:617
+#: src/Utils.php:625
 msgid "Insured Shipping"
 msgstr "Verzekerd verzenden"
 
@@ -1790,13 +1790,13 @@ msgstr "Verzekerd verzenden"
 msgid "Default automatic letterboxparcel product"
 msgstr "Standaard verzendoptie voor automatische brievenbuspakjes"
 
-#: src/Order/Base.php:270
+#: src/Order/Base.php:314
 #: src/Shipping_Method/Settings.php:624
 #: src/Shipping_Method/Settings.php:707
 msgid "Letterboxparcel Standard (24 hours)"
 msgstr "Brievenbuspakje standaard (24 uur)"
 
-#: src/Order/Base.php:282
+#: src/Order/Base.php:326
 #: src/Shipping_Method/Settings.php:625
 #: src/Shipping_Method/Settings.php:708
 msgid "Letterboxparcel 48 hours"
@@ -1825,52 +1825,52 @@ msgstr ""
 msgid "Please specify a \"%s\" argument"
 msgstr "Specificeer een “%s” argument"
 
-#: src/Utils.php:613
+#: src/Utils.php:621
 msgid "Packet"
 msgstr ""
 
-#: src/Utils.php:616
+#: src/Utils.php:624
 msgid "Track & Trace"
 msgstr ""
 
-#: src/Utils.php:618
+#: src/Utils.php:626
 msgid "Delivery Code at Door"
 msgstr "Bezorgcode aan de deur"
 
-#: src/Utils.php:626
+#: src/Utils.php:634
 msgid "Parcels Non-EU Insured"
 msgstr "Non-EU Pakket + Track & Trace + Verzekerd Verzenden"
 
-#: src/Utils.php:627
+#: src/Utils.php:635
 msgid "Parcels non-EU Insured Plus"
 msgstr "Non-EU Pakket + Track & Trace + Verzekerd Verzenden Plus"
 
-#: src/Utils.php:633
+#: src/Utils.php:641
 msgid "Parcels EU"
 msgstr "Pakketten EU"
 
-#: src/Utils.php:634
-#: src/Utils.php:641
+#: src/Utils.php:642
+#: src/Utils.php:649
 msgid "Insured Plus"
 msgstr "Verzekerd Verzenden Plus"
 
-#: src/Utils.php:640
+#: src/Utils.php:648
 msgid "Parcels Non-EU"
 msgstr "Pakketten non-EU"
 
-#: src/Utils.php:1257
+#: src/Utils.php:1265
 msgid "Letterboxparcel (24h)"
 msgstr "Brievenbuspakje (24 uur)"
 
-#: src/Utils.php:1268
+#: src/Utils.php:1276
 msgid "Letterboxparcel (48h)"
 msgstr "Brievenbuspakje (48 uur)"
 
-#: src/Utils.php:1282
+#: src/Utils.php:1290
 msgid "Letterbox 48"
 msgstr "Brievenbuspakje 48"
 
-#: src/Utils.php:1285
+#: src/Utils.php:1293
 msgid "Letterbox 24"
 msgstr "Brievenbuspakje 24"
 

--- a/languages/postnl-for-woocommerce.pot
+++ b/languages/postnl-for-woocommerce.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-02T10:25:48+00:00\n"
+"POT-Creation-Date: 2026-07-20T09:17:41+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: postnl-for-woocommerce\n"
@@ -40,14 +40,14 @@ msgid "https://postnl.post/"
 msgstr ""
 
 #: src/Checkout_Blocks/Extend_Block_Core.php:89
-#: src/Frontend/Container.php:489
+#: src/Frontend/Container.php:503
 msgid "This is not a valid address!"
 msgstr ""
 
 #: src/Checkout_Blocks/Extend_Block_Core.php:104
 #: src/Frontend/Checkout_Fields.php:65
 #: src/Frontend/Checkout_Fields.php:66
-#: src/Order/Single.php:539
+#: src/Order/Single.php:546
 msgid "House number"
 msgstr ""
 
@@ -76,12 +76,12 @@ msgid "Pick up at PostNL-point"
 msgstr ""
 
 #: src/Frontend/Base.php:171
-#: src/Order/Single.php:328
+#: src/Order/Single.php:335
 msgid "Date:"
 msgstr ""
 
 #: src/Frontend/Base.php:175
-#: src/Order/Single.php:332
+#: src/Order/Single.php:339
 msgid "Time:"
 msgstr ""
 
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Street Name"
 msgstr ""
 
-#: src/Frontend/Container.php:120
+#: src/Frontend/Container.php:138
 msgid "Delivery Days"
 msgstr ""
 
-#: src/Frontend/Container.php:121
+#: src/Frontend/Container.php:139
 #: src/Frontend/Dropoff_Points.php:52
 #: build/postnl-container-frontend.js:1
 #: client/checkout/postnl-container/block.js:283
@@ -173,48 +173,48 @@ msgstr ""
 msgid "Incomplete user data."
 msgstr ""
 
-#: src/Helper/Mapping.php:30
+#: src/Helper/Mapping.php:32
 #: src/Shipping_Method/Settings.php:372
 msgid "Morning Delivery"
 msgstr ""
 
-#: src/Helper/Mapping.php:31
+#: src/Helper/Mapping.php:33
 msgid "Standard Shipment"
 msgstr ""
 
-#: src/Helper/Mapping.php:32
+#: src/Helper/Mapping.php:34
 #: src/Shipping_Method/Settings.php:390
 msgid "Evening Delivery"
 msgstr ""
 
-#: src/Helper/Mapping.php:35
+#: src/Helper/Mapping.php:37
 msgid "Pickup at PostNL Point"
 msgstr ""
 
-#: src/Helper/Mapping.php:40
+#: src/Helper/Mapping.php:42
 #: src/Shipping_Method/Settings.php:642
-#: src/Utils.php:614
+#: src/Utils.php:622
 msgid "Standard Shipment Belgium"
 msgstr ""
 
-#: src/Helper/Mapping.php:43
+#: src/Helper/Mapping.php:45
 msgid "Pickup at PostNL Point Belgium"
 msgstr ""
 
-#: src/Helper/Mapping.php:46
-#: src/Helper/Mapping.php:51
-#: src/Helper/Mapping.php:52
+#: src/Helper/Mapping.php:48
+#: src/Helper/Mapping.php:53
+#: src/Helper/Mapping.php:54
 #: src/Order/Bulk.php:518
 msgid "EU Parcel"
 msgstr ""
 
-#: src/Helper/Mapping.php:47
-#: src/Helper/Mapping.php:53
+#: src/Helper/Mapping.php:49
+#: src/Helper/Mapping.php:55
 #: src/Order/Bulk.php:519
 msgid "Non-EU Shipment"
 msgstr ""
 
-#: src/Helper/Mapping.php:50
+#: src/Helper/Mapping.php:52
 msgid "Belgium Domestic"
 msgstr ""
 
@@ -238,136 +238,136 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/Order/Base.php:198
+#: src/Order/Base.php:242
 msgid "ID Check (18+): "
 msgstr ""
 
-#: src/Order/Base.php:210
+#: src/Order/Base.php:254
 msgid "Insured Shipping: "
 msgstr ""
 
-#: src/Order/Base.php:222
+#: src/Order/Base.php:266
 msgid "Insured Plus: "
 msgstr ""
 
-#: src/Order/Base.php:234
+#: src/Order/Base.php:278
 msgid "Return if no answer: "
 msgstr ""
 
-#: src/Order/Base.php:246
+#: src/Order/Base.php:290
 msgid "Signature on Delivery: "
 msgstr ""
 
-#: src/Order/Base.php:258
+#: src/Order/Base.php:302
 msgid "Only Home Address: "
 msgstr ""
 
-#: src/Order/Base.php:270
+#: src/Order/Base.php:314
 #: src/Shipping_Method/Settings.php:624
 #: src/Shipping_Method/Settings.php:707
 msgid "Letterboxparcel Standard (24 hours)"
 msgstr ""
 
-#: src/Order/Base.php:282
+#: src/Order/Base.php:326
 #: src/Shipping_Method/Settings.php:625
 #: src/Shipping_Method/Settings.php:708
 msgid "Letterboxparcel 48 hours"
 msgstr ""
 
-#: src/Order/Base.php:294
+#: src/Order/Base.php:338
 msgid "Packets: "
 msgstr ""
 
-#: src/Order/Base.php:306
+#: src/Order/Base.php:350
 msgid "Mailbox Packet (International): "
 msgstr ""
 
-#: src/Order/Base.php:318
+#: src/Order/Base.php:362
 msgid "Track & Trace: "
 msgstr ""
 
-#: src/Order/Base.php:330
+#: src/Order/Base.php:374
 msgid "Delivery code at the door: "
 msgstr ""
 
-#: src/Order/Base.php:348
+#: src/Order/Base.php:392
 #: src/Order/Bulk.php:436
 msgid "Number of Labels: "
 msgstr ""
 
-#: src/Order/Base.php:379
+#: src/Order/Base.php:423
 #: src/Order/Bulk.php:455
 msgid "Create Return Label: "
 msgstr ""
 
-#: src/Order/Base.php:394
+#: src/Order/Base.php:438
 #: src/Order/Bulk.php:467
 msgid "Start position printing label: "
 msgstr ""
 
-#: src/Order/Base.php:398
+#: src/Order/Base.php:442
 #: src/Order/Bulk.php:473
 msgid "Top Left"
 msgstr ""
 
-#: src/Order/Base.php:399
+#: src/Order/Base.php:443
 #: src/Order/Bulk.php:474
 msgid "Top Right"
 msgstr ""
 
-#: src/Order/Base.php:400
+#: src/Order/Base.php:444
 #: src/Order/Bulk.php:475
 msgid "Bottom Left"
 msgstr ""
 
-#: src/Order/Base.php:401
+#: src/Order/Base.php:445
 #: src/Order/Bulk.php:476
 msgid "Bottom Right"
 msgstr ""
 
-#: src/Order/Base.php:532
-#: src/Order/Base.php:725
-#: src/Order/Single.php:515
-#: src/Order/Single.php:620
-#: src/Order/Single.php:693
+#: src/Order/Base.php:576
+#: src/Order/Base.php:781
+#: src/Order/Single.php:522
+#: src/Order/Single.php:627
+#: src/Order/Single.php:698
 msgid "Order does not exist!"
 msgstr ""
 
-#: src/Order/Base.php:822
+#: src/Order/Base.php:876
 msgid "Cannot create the barcode."
 msgstr ""
 
-#: src/Order/Base.php:947
+#: src/Order/Base.php:999
 msgid "Cannot create return barcode."
 msgstr ""
 
-#: src/Order/Base.php:1140
+#: src/Order/Base.php:1192
 msgid "There are no files to merge."
 msgstr ""
 
-#: src/Order/Base.php:1144
+#: src/Order/Base.php:1196
 msgid "\"Imagick\" must be installed on the server to merge png files."
 msgstr ""
 
-#: src/Order/Base.php:1229
-#: src/Order/Base.php:1328
+#: src/Order/Base.php:1299
+#: src/Order/Base.php:1430
 msgid "Cannot create the label. Label content is missing"
 msgstr ""
 
-#: src/Order/Base.php:1260
+#: src/Order/Base.php:1346
 msgid "Cannot create the return label. Label content is missing"
 msgstr ""
 
-#: src/Order/Base.php:1291
+#: src/Order/Base.php:1393
 msgid "Cannot create the letterbox. Label content is missing"
 msgstr ""
 
-#: src/Order/Base.php:1322
+#: src/Order/Base.php:1424
 msgid "Cannot create the label. Barcode data is missing"
 msgstr ""
 
 #. translators: %s the current service.
-#: src/Order/Base.php:1457
+#: src/Order/Base.php:1559
 msgid "%s Tracking Number: {tracking-link}"
 msgstr ""
 
@@ -470,97 +470,97 @@ msgstr ""
 msgid "Fits through letterbox"
 msgstr ""
 
-#: src/Order/Single.php:135
+#: src/Order/Single.php:131
 msgid "Label & Tracking"
 msgstr ""
 
-#: src/Order/Single.php:262
+#: src/Order/Single.php:267
 msgid "Delivery Type:"
 msgstr ""
 
-#: src/Order/Single.php:293
+#: src/Order/Single.php:298
 msgid "Delivery Date:"
 msgstr ""
 
-#: src/Order/Single.php:323
+#: src/Order/Single.php:330
 msgid "Pickup Address:"
 msgstr ""
 
-#: src/Order/Single.php:360
+#: src/Order/Single.php:367
 msgid "Activate return function"
 msgstr ""
 
-#: src/Order/Single.php:363
+#: src/Order/Single.php:370
 msgid "Return function is activated for this label"
 msgstr ""
 
-#: src/Order/Single.php:366
+#: src/Order/Single.php:373
 msgid "Click here to activate the return function of this label"
 msgstr ""
 
-#: src/Order/Single.php:384
+#: src/Order/Single.php:391
 msgid "Send email with Smart Return"
 msgstr ""
 
-#: src/Order/Single.php:422
+#: src/Order/Single.php:429
 msgid "Create Shipment"
 msgstr ""
 
-#: src/Order/Single.php:424
+#: src/Order/Single.php:431
 msgid "Print Label"
 msgstr ""
 
-#: src/Order/Single.php:426
+#: src/Order/Single.php:433
 msgid "Delete Label"
 msgstr ""
 
-#: src/Order/Single.php:432
+#: src/Order/Single.php:439
 msgid "Print Return Label"
 msgstr ""
 
-#: src/Order/Single.php:437
+#: src/Order/Single.php:444
 msgid "Print Letterbox"
 msgstr ""
 
-#: src/Order/Single.php:456
-#: src/Order/Single.php:501
-#: src/Order/Single.php:607
-#: src/Order/Single.php:680
+#: src/Order/Single.php:463
+#: src/Order/Single.php:508
+#: src/Order/Single.php:614
+#: src/Order/Single.php:685
 msgid "Cannot find nonce field!"
 msgstr ""
 
-#: src/Order/Single.php:462
-#: src/Order/Single.php:507
+#: src/Order/Single.php:469
+#: src/Order/Single.php:514
 msgid "Nonce is invalid!"
 msgstr ""
 
-#: src/Order/Single.php:612
-#: src/Order/Single.php:685
+#: src/Order/Single.php:619
+#: src/Order/Single.php:690
 msgid "Nonce is invalid"
 msgstr ""
 
-#: src/Order/Single.php:624
+#: src/Order/Single.php:631
 msgid "Already activated!"
 msgstr ""
 
-#: src/Order/Single.php:640
+#: src/Order/Single.php:645
 msgid "Unknown error."
 msgstr ""
 
 #. Translators: %s is the error message.
-#: src/Order/Single.php:664
+#: src/Order/Single.php:669
 msgid "Error: %s"
 msgstr ""
 
-#: src/Order/Single.php:720
+#: src/Order/Single.php:723
 msgid "PrintcodeLabel could not found"
 msgstr ""
 
-#: src/Order/Single.php:751
+#: src/Order/Single.php:754
 msgid "Email could not be send"
 msgstr ""
 
-#: src/Order/Single.php:782
+#: src/Order/Single.php:785
 msgid "18+ Adults Only"
 msgstr ""
 
@@ -673,21 +673,6 @@ msgstr ""
 msgid "“18+” and “Letterbox Parcel” cannot be enabled together. Letterbox has been disabled automatically."
 msgstr ""
 
-#: src/Rest_API/Barcode/Item_Info.php:66
-#: src/Rest_API/Shipping/Item_Info.php:140
-msgid "Order ID does not exist!"
-msgstr ""
-
-#: src/Rest_API/Barcode/Item_Info.php:136
-#: src/Rest_API/Shipping/Item_Info.php:356
-msgid "Customer Code is empty!"
-msgstr ""
-
-#: src/Rest_API/Barcode/Item_Info.php:139
-#: src/Rest_API/Shipping/Item_Info.php:359
-msgid "Customer Number is empty!"
-msgstr ""
-
 #: src/Rest_API/Base.php:273
 #: src/Rest_API/Base.php:282
 #: src/Rest_API/Base.php:290
@@ -709,8 +694,8 @@ msgid "Shipping \"City\" is empty!"
 msgstr ""
 
 #: src/Rest_API/Base_Info.php:182
-#: src/Rest_API/Checkout/Item_Info.php:260
-#: src/Rest_API/Postcode_Check/Item_Info.php:88
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:260
+#: src/Rest_API/Legacy/Postcode_Check/Item_Info.php:88
 msgid "Shipping \"Postcode\" is empty!"
 msgstr ""
 
@@ -735,140 +720,155 @@ msgstr ""
 msgid "Store country is not configured!"
 msgstr ""
 
-#: src/Rest_API/Checkout/Item_Info.php:119
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:66
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:140
+msgid "Order ID does not exist!"
+msgstr ""
+
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:136
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:356
+msgid "Customer Code is empty!"
+msgstr ""
+
+#: src/Rest_API/Legacy/Barcode/Item_Info.php:139
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:359
+msgid "Customer Number is empty!"
+msgstr ""
+
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:119
 msgid "Order date is empty!"
 msgstr ""
 
-#: src/Rest_API/Checkout/Item_Info.php:123
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:123
 msgid "Shipping duration is empty!"
 msgstr ""
 
-#: src/Rest_API/Checkout/Item_Info.php:131
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:131
 msgid "Wrong format for cut off time!"
 msgstr ""
 
-#: src/Rest_API/Checkout/Item_Info.php:215
+#: src/Rest_API/Legacy/Checkout/Item_Info.php:215
 msgid "Locations value is not a number!"
 msgstr ""
 
-#: src/Rest_API/Postcode_Check/Item_Info.php:85
+#: src/Rest_API/Legacy/Postcode_Check/Item_Info.php:85
 msgid "Shipping \"House number\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipment_and_Return/Item_Info.php:82
+#: src/Rest_API/Legacy/Shipment_and_Return/Item_Info.php:82
 msgid "Given id is not an Order"
 msgstr ""
 
-#: src/Rest_API/Shipment_and_Return/Item_Info.php:86
+#: src/Rest_API/Legacy/Shipment_and_Return/Item_Info.php:86
 msgid "Missing barcode"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:353
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:353
 msgid "Location Code is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:368
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:368
 msgid "Store email is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:374
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:374
 msgid "Wrong format for store email!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:429
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:429
 msgid "Order ID is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:432
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:432
 msgid "Order number is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:435
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:435
 msgid "Barcode is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:447
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:447
 msgid "Product code is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:451
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:451
 msgid "Wrong format for product code!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:496
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:496
 msgid "Total weight is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:511
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:511
 msgid "Customer email is not valid!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:541
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:541
 msgid "Delivery day \"Date\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:557
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:557
 msgid "Delivery day \"From\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:570
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:570
 msgid "Delivery day \"To\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:586
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:586
 msgid "Delivery day \"Type\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:610
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:610
 msgid "Pickup \"Date\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:626
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:626
 msgid "Pickup \"Time\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:638
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:638
 msgid "Pickup \"Company name\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:647
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:647
 msgid "Pickup \"Address 1\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:662
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:662
 msgid "Pickup Point \"City\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:671
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:671
 msgid "Pickup Point \"Postcode\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:683
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:683
 msgid "Pickup Point \"Country\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:817
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:817
 msgid "Item HS Code must be between 6 and 20 characters long"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:830
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:830
 msgid "Item \"Product ID\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:833
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:833
 msgid "Item \"Product SKU\" is empty!"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:850
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:850
 msgid "Item quantity must be more than 1"
 msgstr ""
 
-#: src/Rest_API/Shipping/Item_Info.php:1096
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:1096
 msgid "Max weight for Mailbox Packet is 2kg!"
 msgstr ""
 
 #. Translators: %s is the order total.
-#: src/Rest_API/Shipping/Item_Info.php:1119
+#: src/Rest_API/Legacy/Shipping/Item_Info.php:1119
 msgid "Insurance amount for EU shipments cannot exceed €5000. Your total is: %d"
 msgstr ""
 
@@ -1609,13 +1609,13 @@ msgid "Select a default shipping option for domestic orders that are shipped wit
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:617
-#: src/Utils.php:607
+#: src/Utils.php:615
 msgid "Standard shipment"
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:618
 #: src/Shipping_Method/Settings.php:695
-#: src/Utils.php:608
+#: src/Utils.php:616
 msgid "ID Check (18+)"
 msgstr ""
 
@@ -1625,17 +1625,17 @@ msgid "ID Check (18+) + Insured Shipping"
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:621
-#: src/Utils.php:609
+#: src/Utils.php:617
 msgid "Return if no answer"
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:622
-#: src/Utils.php:610
+#: src/Utils.php:618
 msgid "Signature on Delivery"
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:623
-#: src/Utils.php:611
+#: src/Utils.php:619
 msgid "Only Home Address"
 msgstr ""
 
@@ -1690,7 +1690,7 @@ msgstr ""
 #: src/Shipping_Method/Settings.php:646
 #: src/Shipping_Method/Settings.php:663
 #: src/Shipping_Method/Settings.php:680
-#: src/Utils.php:615
+#: src/Utils.php:623
 msgid "Boxable Packet"
 msgstr ""
 
@@ -1769,7 +1769,7 @@ msgid "Standard Shipping"
 msgstr ""
 
 #: src/Shipping_Method/Settings.php:696
-#: src/Utils.php:617
+#: src/Utils.php:625
 msgid "Insured Shipping"
 msgstr ""
 
@@ -1799,56 +1799,56 @@ msgstr ""
 msgid "Please specify a \"%s\" argument"
 msgstr ""
 
-#: src/Utils.php:612
+#: src/Utils.php:620
 msgid "Letterbox"
 msgstr ""
 
-#: src/Utils.php:613
+#: src/Utils.php:621
 msgid "Packet"
 msgstr ""
 
-#: src/Utils.php:616
+#: src/Utils.php:624
 msgid "Track & Trace"
 msgstr ""
 
-#: src/Utils.php:618
+#: src/Utils.php:626
 msgid "Delivery Code at Door"
 msgstr ""
 
-#: src/Utils.php:626
+#: src/Utils.php:634
 msgid "Parcels Non-EU Insured"
 msgstr ""
 
-#: src/Utils.php:627
+#: src/Utils.php:635
 msgid "Parcels non-EU Insured Plus"
 msgstr ""
 
-#: src/Utils.php:633
+#: src/Utils.php:641
 msgid "Parcels EU"
 msgstr ""
 
-#: src/Utils.php:634
-#: src/Utils.php:641
+#: src/Utils.php:642
+#: src/Utils.php:649
 msgid "Insured Plus"
 msgstr ""
 
-#: src/Utils.php:640
+#: src/Utils.php:648
 msgid "Parcels Non-EU"
 msgstr ""
 
-#: src/Utils.php:1257
+#: src/Utils.php:1265
 msgid "Letterboxparcel (24h)"
 msgstr ""
 
-#: src/Utils.php:1268
+#: src/Utils.php:1276
 msgid "Letterboxparcel (48h)"
 msgstr ""
 
-#: src/Utils.php:1282
+#: src/Utils.php:1290
 msgid "Letterbox 48"
 msgstr ""
 
-#: src/Utils.php:1285
+#: src/Utils.php:1293
 msgid "Letterbox 24"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,8 +83,6 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
-* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
-* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 5.9.9 (2026-xx-xx) =
+* Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
+* Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 = 5.9.9 (2026-xx-xx) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 * Fix: Prevented a critical error on the order edit page for orders whose saved delivery date was in an unexpected format.
+* Fix: Plugin no longer fails to load on PHP 7.4-8.1 due to a development-only API SDK dependency being included in the production build.
 
 = 5.9.8 (2026-07-07) =
 * Add: Letterboxparcel 48 hours as a selectable option in the domestic default shipping option, the bulk Change Shipping Options action, and the Label & Tracking menu.

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -731,6 +731,18 @@ abstract class Base {
 	 * @return String.
 	 */
 	public function get_delivery_type( $order ) {
+		// A letterbox order has no delivery-day or pickup type, so the frontend
+		// mapping below would fall through to the generic "Standard Shipment"
+		// label. Surface the resolved 24h/48h variant instead, mirroring the
+		// selected shipping option so the summary matches the checkbox.
+		$shipping_options = $this->get_shipping_options( $order );
+		if ( 'yes' === ( $shipping_options['letterbox_48'] ?? '' ) ) {
+			return Utils::get_letterbox_label_48h();
+		}
+		if ( 'yes' === ( $shipping_options['letterbox'] ?? '' ) ) {
+			return Utils::get_letterbox_label_24h();
+		}
+
 		$from_country      = Utils::get_base_country();
 		$to_country        = $order->get_shipping_country();
 		$to_state          = $order->get_shipping_state();

--- a/src/Order/Single.php
+++ b/src/Order/Single.php
@@ -298,9 +298,11 @@ class Single extends Base {
 			<label for="postnl_pickup_points"><?php esc_html_e( 'Delivery Date:', 'postnl-for-woocommerce' ); ?></label>
 			<?php
 			foreach ( $filtered_infos as $info_idx => $info_val ) {
-				// Convert to the Dutch date format
+				// Convert to the Dutch date format, falling back to the stored value
+				// when it does not parse as Y-m-d so a malformed date cannot fatal the
+				// whole order edit screen via date_format( false, ... ).
 				$date_obj   = date_create_from_format( 'Y-m-d', $info_val );
-				$dutch_date = date_format( $date_obj, 'd/m/Y' );
+				$dutch_date = ( false !== $date_obj ) ? date_format( $date_obj, 'd/m/Y' ) : $info_val;
 				?>
 				<div class="postnl-info <?php echo esc_attr( $info_idx ); ?>">
 					<?php echo esc_html( $dutch_date ); ?>

--- a/tests/php/integration/DeliveryDateHtmlTest.php
+++ b/tests/php/integration/DeliveryDateHtmlTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Integration tests for the order metabox delivery-date rendering.
+ *
+ * Single::generate_delivery_date_html() converts the stored delivery_day_date
+ * to the Dutch d/m/Y format for display. The stored value originates from
+ * sanitised frontend input, so a value that does not parse as Y-m-d must not be
+ * allowed to fatal the whole order edit screen.
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Tests\Integration;
+
+use PostNLWooCommerce\Tests\IntegrationTestCase;
+use PostNLWooCommerce\Order\Single;
+use PostNLWooCommerce\Shipping_Method\Settings;
+
+/**
+ * Covers the delivery-date render guard on the order metabox.
+ */
+class DeliveryDateHtmlTest extends IntegrationTestCase {
+
+	/**
+	 * @testdox An unparseable delivery date renders without fataling the order screen.
+	 */
+	public function test_generate_delivery_date_html_does_not_fatal_on_unparseable_date(): void {
+		$handler = $this->make_single_handler();
+
+		$output = $this->capture_delivery_date_html( $handler, '31-12-2026' );
+
+		$this->assertStringContainsString(
+			'31-12-2026',
+			$output,
+			'A delivery date that is not Y-m-d must fall back to the stored value instead of throwing.'
+		);
+	}
+
+	/**
+	 * @testdox A valid Y-m-d delivery date is rendered in the Dutch d/m/Y format.
+	 */
+	public function test_generate_delivery_date_html_formats_valid_date_as_dutch(): void {
+		$handler = $this->make_single_handler();
+
+		$output = $this->capture_delivery_date_html( $handler, '2026-12-31' );
+
+		$this->assertStringContainsString(
+			'31/12/2026',
+			$output,
+			'A valid Y-m-d date must still be converted to the Dutch d/m/Y format.'
+		);
+	}
+
+	/**
+	 * Render generate_delivery_date_html() and return the captured markup.
+	 *
+	 * @param Single $handler Order handler under test.
+	 * @param string $date    Stored delivery_day_date value.
+	 * @return string
+	 */
+	private function capture_delivery_date_html( Single $handler, string $date ): string {
+		ob_start();
+		try {
+			$handler->generate_delivery_date_html( array( 'delivery_day_date' => $date ) );
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		return $output;
+	}
+
+	/**
+	 * A minimal concrete Order\Single whose constructor does not register the
+	 * real admin hooks.
+	 *
+	 * @return Single
+	 */
+	private function make_single_handler(): Single {
+		return new class() extends Single {
+			public function __construct() {
+				$this->settings  = Settings::get_instance();
+				$this->meta_name = '_' . $this->prefix . 'order_metadata';
+			}
+			public function init_hooks() {}
+		};
+	}
+}

--- a/tests/php/integration/LetterboxTypeTest.php
+++ b/tests/php/integration/LetterboxTypeTest.php
@@ -374,19 +374,37 @@ class LetterboxTypeTest extends IntegrationTestCase {
 	}
 
 	/**
-	 * @testdox A non-letterbox order never reports a letterbox label as its delivery type.
+	 * @testdox A saved non-letterbox selection wins over a letterbox merchant default, so no letterbox label leaks onto the order.
 	 */
-	public function test_get_delivery_type_does_not_leak_letterbox_label_for_non_letterbox_order(): void {
+	public function test_get_delivery_type_prefers_saved_non_letterbox_choice_over_letterbox_default(): void {
+		// Force the store to default to Letterbox 48 and make the order auto
+		// letterbox eligible, so with no explicit choice the delivery type would
+		// resolve to the 48h label. The saved non-letterbox selection must take
+		// precedence over that default and never surface a letterbox label.
+		Settings::get_instance()->settings['default_automatic_letterboxparcel_product'] = 'letterbox_48';
+
 		$handler = $this->make_order_handler();
 
 		$order = new \WC_Order();
+		$order->set_shipping_country( 'NL' );
+		$order->update_meta_data( '_postnl_letterbox', true );
 		$order->save();
 		$this->order_ids[] = $order->get_id();
 
+		$handler->seed_backend_options( $order, array( 'delivery_day' => 'yes' ) );
+
 		$delivery_type = $handler->get_delivery_type( wc_get_order( $order->get_id() ) );
 
-		$this->assertNotSame( Utils::get_letterbox_label_24h(), $delivery_type );
-		$this->assertNotSame( Utils::get_letterbox_label_48h(), $delivery_type );
+		$this->assertNotSame(
+			Utils::get_letterbox_label_24h(),
+			$delivery_type,
+			'A saved non-letterbox selection must not surface the 24h letterbox label.'
+		);
+		$this->assertNotSame(
+			Utils::get_letterbox_label_48h(),
+			$delivery_type,
+			'The letterbox merchant default must not override the saved non-letterbox selection.'
+		);
 	}
 
 	/**

--- a/tests/php/integration/LetterboxTypeTest.php
+++ b/tests/php/integration/LetterboxTypeTest.php
@@ -326,6 +326,70 @@ class LetterboxTypeTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * @testdox A 48h letterbox order reports the 48h label as its delivery type instead of "Standard Shipment".
+	 */
+	public function test_get_delivery_type_returns_48h_label_for_letterbox_order(): void {
+		// A 24h merchant default proves the label is driven by the stored 48h
+		// variant, not the default.
+		Settings::get_instance()->settings['default_automatic_letterboxparcel_product'] = 'letterbox';
+
+		$handler = $this->make_order_handler();
+
+		$order = new \WC_Order();
+		$order->save();
+		$this->order_ids[] = $order->get_id();
+
+		$handler->seed_backend_options( $order, array( 'letterbox' => 'yes' ) );
+		$order->update_meta_data( '_postnl_letterbox_type', 'letterbox_48' );
+		$order->save();
+
+		$this->assertSame(
+			Utils::get_letterbox_label_48h(),
+			$handler->get_delivery_type( wc_get_order( $order->get_id() ) ),
+			'A 48h letterbox order must report the 48h label, not the generic "Standard Shipment".'
+		);
+	}
+
+	/**
+	 * @testdox A 24h letterbox order reports the 24h label as its delivery type.
+	 */
+	public function test_get_delivery_type_returns_24h_label_for_letterbox_order(): void {
+		Settings::get_instance()->settings['default_automatic_letterboxparcel_product'] = 'letterbox_48';
+
+		$handler = $this->make_order_handler();
+
+		$order = new \WC_Order();
+		$order->save();
+		$this->order_ids[] = $order->get_id();
+
+		$handler->seed_backend_options( $order, array( 'letterbox' => 'yes' ) );
+		$order->update_meta_data( '_postnl_letterbox_type', 'letterbox' );
+		$order->save();
+
+		$this->assertSame(
+			Utils::get_letterbox_label_24h(),
+			$handler->get_delivery_type( wc_get_order( $order->get_id() ) ),
+			'A 24h letterbox order must report the 24h label.'
+		);
+	}
+
+	/**
+	 * @testdox A non-letterbox order never reports a letterbox label as its delivery type.
+	 */
+	public function test_get_delivery_type_does_not_leak_letterbox_label_for_non_letterbox_order(): void {
+		$handler = $this->make_order_handler();
+
+		$order = new \WC_Order();
+		$order->save();
+		$this->order_ids[] = $order->get_id();
+
+		$delivery_type = $handler->get_delivery_type( wc_get_order( $order->get_id() ) );
+
+		$this->assertNotSame( Utils::get_letterbox_label_24h(), $delivery_type );
+		$this->assertNotSame( Utils::get_letterbox_label_48h(), $delivery_type );
+	}
+
+	/**
 	 * A minimal concrete Order\Base whose only dependencies are the settings
 	 * instance and the meta name. The constructor is overridden so the real one
 	 * does not register admin hooks, which would leak into sibling tests.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally? <!-- Integration tests require wp-env/Docker, unavailable in my setup; verified with `php -l` and by matching the existing LetterboxTypeTest harness. -->
* [ ] Have you tested both blocks/non-blocks cart/checkout? <!-- Admin-only change (order edit meta box); not a checkout change. -->
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest? <!-- N/A — admin-only. -->
* [ ] Have you successfully placed an order as both a logged-in user and a guest? <!-- N/A — admin-only. -->
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

ClickUp: https://app.clickup.com/t/868kdd9c0

On the order edit page, Letterboxparcel orders showed **"Standard Shipment"** as the *Delivery Type* in the Label & Tracking box, even though the order was correctly shipped as Letterbox (the shipping line item and the "Letterboxparcel 48 hours" checkbox were both right).

Root cause: `Order\Base::get_delivery_type()` only maps delivery-day/pickup types via `Mapping::delivery_type()` and has no letterbox awareness, so a letterbox order falls through to the `Daytime` → "Standard Shipment" default.

Fix: `get_delivery_type()` now first checks the same resolved shipping options that drive the meta-box checkboxes and returns the letterbox label (`Letterboxparcel (48h)` / `(24h)`). The summary line therefore always agrees with the ticked checkbox and the shipping line item. Pure display fix — product-code selection (2928/2948) and label generation are unchanged.

Added 3 regression tests to `LetterboxTypeTest` and a `5.9.9` changelog entry.

### How to test the changes in this Pull Request:

1. In PostNL settings (NL store), set *Default automatic letterboxparcel product* to **Letterboxparcel 48**.
2. Place an order for a letterbox-eligible product (e.g. the "Sunglasses" test product).
3. Open the order in the admin. In the **Label & Tracking** box, confirm *Delivery Type* now reads **Letterboxparcel (48h)** (previously "Standard Shipment"), and that it matches the ticked "Letterboxparcel 48 hours" checkbox and the shipping line item.
4. Repeat with the default set to **Letterboxparcel Standard (24 hours)** and confirm *Delivery Type* reads **Letterboxparcel (24h)**.
5. Confirm a normal (non-letterbox) order still shows its usual delivery type (Standard Shipment / Evening / Pickup, etc.).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
