### PR TITLE
Fix Letterbox 48 reverting to Standard Shipment on legacy-storage bulk label creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,37 @@ JS tests use Jest with `@testing-library/react`. Mocks in `tests/js/__mocks__/` 
 - `@wordpress/components`
 - `@woocommerce/settings`
 
-PHP has no unit test suite — only PHPCS linting. All PHP testing is manual.
+PHP has two PHPUnit suites, both run in CI (`.github/workflows/php-tests.yml`):
+
+- **Unit** (`tests/php/unit`, `phpunit-unit.xml.dist`) is pure PHP with no WordPress bootstrap, so it runs without wp-env. Run it with `npm run test:php:unit`.
+- **Integration** (`tests/php/integration`, `phpunit-integration.xml.dist`) needs a real WordPress and runs inside the wp-env `tests-cli` container. Run it with `npm run test:php:integration`.
+
+Both commands need dev dependencies installed first (`npm run test:php:setup`, or `composer install` on the host, since wp-env mounts `vendor/` into the container). Run both suites in wp-env rather than against a host PHP/MySQL, which avoids version and port conflicts.
+
+PHPCS still applies on top of the suites, via `composer run check-php`.
+
+### Review Triggers
+
+Two classes of change have shipped storage-mode and persistence bugs to production. Both are cheap to check once you know to look, so treat them as hard gates rather than judgment calls.
+
+**1. Code that branches on the current admin screen must be tested under both HPOS and legacy storage.**
+
+The orders list is a different screen in each mode, and that difference is invisible in the diff:
+
+| | Legacy (posts) | HPOS |
+|---|---|---|
+| `$screen->base` | `edit` | `woocommerce_page_wc-orders` |
+| `$screen->post_type` | `shop_order` | `''` (empty) |
+
+Any condition reading `get_current_screen()`, a screen ID, `post_type === 'shop_order'`, or hooking the orders list or its bulk actions will fire in one mode and not the other. Toggle storage with the `woocommerce_custom_orders_table_enabled` option and exercise the path in both. Do not assume the mode you happen to be running is the one the merchant uses.
+
+This does not mean every PR needs a storage matrix. It applies only when the change touches screen-dependent code.
+
+**2. A field list consumed by both rendering and persistence needs every consumer traced.**
+
+`Order\Base::meta_box_fields()` drives both the admin UI and `save_meta_value()`. A flag that reads as display-only, such as `show_in_bulk`, will silently govern what gets saved if a filter trims the list before the save path reads it. A dropped field is not an error, it is a blank value, so the failure is silent and shows up as a shipment reverting to a default.
+
+When adding a field or a filtering flag, list the callers of `meta_box_fields()` and confirm each one gets the set it expects. Persistence should read the untrimmed `save` context, never the display set.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ PostNL’s official extension for WooCommerce on WordPress. Manage your national
 
 ## Changelog
 
+### 6.0.0
+* Fix: Letterboxparcel 48-hour orders reverted to Standard Shipment when the label was generated with the bulk action on the classic orders list.
+
 ### 5.9.9
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** PostNL for WooCommerce ***
 
+= 6.0.0 (2026-xx-xx) =
+* Fix: Letterboxparcel 48-hour orders reverted to Standard Shipment when the label was generated with the bulk action on the classic orders list.
+
 = 5.9.9 (2026-07-20) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Follow these instructions (https://www.postnl.nl/Images/aanvragen-api-key-stappe
 
 == Changelog ==
 
+= 6.0.0 (2026-xx-xx) =
+* Fix: Letterboxparcel 48-hour orders reverted to Standard Shipment when the label was generated with the bulk action on the classic orders list.
+
 = 5.9.9 (2026-07-20) =
 * Fix: Order edit page showed "Standard Shipment" as the delivery type for Letterboxparcel orders instead of the selected 24-hour or 48-hour variant.
 

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -230,9 +230,15 @@ abstract class Base {
 	/**
 	 * List of meta box fields.
 	 *
-	 * @param \WC_Order $order WooCommerce order ID.
+	 * @param \WC_Order $order   WooCommerce order ID.
+	 * @param string    $context Why the fields are requested: 'display' (default) when
+	 *                           rendering the admin UI, or 'save' when persisting a
+	 *                           submitted selection. The bulk-modal trimming
+	 *                           ( Bulk::additional_meta_box ) applies to 'display' only, so
+	 *                           it can never silently drop a persisted option such as
+	 *                           Letterbox 48 or ID Check during a bulk label generation.
 	 */
-	public function meta_box_fields( $order = false ) {
+	public function meta_box_fields( $order = false, $context = 'display' ) {
 
 		$default_options = $this->get_shipping_options( $order );
 		$fields          = array(
@@ -454,7 +460,8 @@ abstract class Base {
 
 		return apply_filters(
 			'postnl_order_meta_box_fields',
-			$fields
+			$fields,
+			$context
 		);
 	}
 
@@ -590,7 +597,10 @@ abstract class Base {
 		$nonce_fields = array_values( $this->get_nonce_fields() );
 
 		// Loop through inputs within id 'shipment-postnl-label-form'.
-		foreach ( $this->meta_box_fields( $order_id ) as $field ) {
+		// Use the 'save' context so the bulk-modal display trim cannot drop a persisted
+		// field (e.g. Letterbox 48 / ID Check) when generating a label from the legacy
+		// orders list bulk action.
+		foreach ( $this->meta_box_fields( $order_id, 'save' ) as $field ) {
 			// Don't save nonce field.
 			if ( $nonce_fields[0]['id'] === $field['id'] ) {
 				continue;

--- a/src/Order/Base.php
+++ b/src/Order/Base.php
@@ -109,8 +109,10 @@ abstract class Base {
 	 * @return array
 	 */
 	public function get_nonce_fields() {
+		// Resolve from the 'save' field set: the nonce is a structural field the save/verify
+		// callers always need, so it must never be subject to the bulk-modal display trim.
 		return array_filter(
-			$this->meta_box_fields(),
+			$this->meta_box_fields( false, 'save' ),
 			function ( $field ) {
 				return ( ! empty( $field['nonce'] ) && true === $field['nonce'] );
 			}
@@ -231,12 +233,7 @@ abstract class Base {
 	 * List of meta box fields.
 	 *
 	 * @param \WC_Order $order   WooCommerce order ID.
-	 * @param string    $context Why the fields are requested: 'display' (default) when
-	 *                           rendering the admin UI, or 'save' when persisting a
-	 *                           submitted selection. The bulk-modal trimming
-	 *                           ( Bulk::additional_meta_box ) applies to 'display' only, so
-	 *                           it can never silently drop a persisted option such as
-	 *                           Letterbox 48 or ID Check during a bulk label generation.
+	 * @param string    $context 'display' (default) when rendering the admin UI, 'save' when persisting.
 	 */
 	public function meta_box_fields( $order = false, $context = 'display' ) {
 

--- a/src/Order/Bulk.php
+++ b/src/Order/Bulk.php
@@ -66,7 +66,7 @@ class Bulk extends Base {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_bulk_assets' ) );
 		add_action( 'admin_footer', array( $this, 'modal_create_label' ) );
 		add_action( 'admin_footer', array( $this, 'modal_change_shipping_options' ) );
-		add_filter( 'postnl_order_meta_box_fields', array( $this, 'additional_meta_box' ), 10, 1 );
+		add_filter( 'postnl_order_meta_box_fields', array( $this, 'additional_meta_box' ), 10, 2 );
 
 		// Display admin notices for bulk actions.
 		add_action( 'admin_notices', array( $this, 'render_messages' ) );
@@ -368,9 +368,17 @@ class Bulk extends Base {
 	/**
 	 * Adding additional meta box in order admin page.
 	 *
-	 * @param array $fields List of fields for order admin page.
+	 * @param array  $fields  List of fields for order admin page.
+	 * @param string $context 'display' when rendering the admin UI, 'save' when persisting.
 	 */
-	public function additional_meta_box( $fields ) {
+	public function additional_meta_box( $fields, $context = 'display' ) {
+		// Trimming is a display concern only. During a save it would silently drop every
+		// show_in_bulk = false field (Letterbox 48, ID Check, ...), reverting the shipment
+		// to Standard when a label is generated from the legacy orders list bulk action.
+		if ( 'save' === $context ) {
+			return $fields;
+		}
+
 		$screen = get_current_screen();
 
 		if ( empty( $screen ) ) {

--- a/tests/php/integration/LetterboxTypeTest.php
+++ b/tests/php/integration/LetterboxTypeTest.php
@@ -408,6 +408,54 @@ class LetterboxTypeTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * @testdox The save context keeps the show_in_bulk = false Letterbox 48 field so a legacy bulk label does not revert to Standard.
+	 */
+	public function test_meta_box_fields_save_context_survives_bulk_display_trim(): void {
+		$handler = $this->make_order_handler();
+
+		$order = new \WC_Order();
+		$order->save();
+		$this->order_ids[] = $order->get_id();
+
+		// Reproduce the legacy orders-list bulk trim ( Bulk::additional_meta_box ): drop
+		// every show_in_bulk = false field, but for the 'display' context only. Before the
+		// fix, meta_box_fields() passed no context to the filter, so the save path was
+		// trimmed too and the injected Letterbox 48 selection was silently dropped, leaving
+		// the label engine to fall back to the Standard product.
+		$trim = static function ( $fields, $context = 'display' ) {
+			if ( 'save' === $context ) {
+				return $fields;
+			}
+
+			return array_filter(
+				$fields,
+				static function ( $field ) {
+					return ! empty( $field['show_in_bulk'] ) && true === $field['show_in_bulk'];
+				}
+			);
+		};
+		add_filter( 'postnl_order_meta_box_fields', $trim, 20, 2 );
+
+		try {
+			$display_ids = wp_list_pluck( $handler->meta_box_fields( $order, 'display' ), 'id' );
+			$save_ids    = wp_list_pluck( $handler->meta_box_fields( $order, 'save' ), 'id' );
+		} finally {
+			remove_filter( 'postnl_order_meta_box_fields', $trim, 20 );
+		}
+
+		$this->assertNotContains(
+			'postnl_letterbox_48',
+			$display_ids,
+			'The bulk modal (display) must still hide the 48h field.'
+		);
+		$this->assertContains(
+			'postnl_letterbox_48',
+			$save_ids,
+			'The save path must keep the 48h field so a bulk label keeps Letterbox 48 instead of reverting to Standard.'
+		);
+	}
+
+	/**
 	 * A minimal concrete Order\Base whose only dependencies are the settings
 	 * instance and the meta name. The constructor is overridden so the real one
 	 * does not register admin hooks, which would leak into sibling tests.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

<!-- Admin-side change: this fixes bulk label generation on the orders list and does not touch cart/checkout. A PHP regression test is added; the local toolchain (phpcs/phpunit) isn't installed here, so the suite should run in wp-env/CI. -->

### Changes proposed in this Pull Request:

Fixes **Letterbox 48 orders reverting to Standard Shipment** when a label is generated via the **bulk action** on the classic **WordPress posts (non-HPOS) orders list**. HPOS stores were unaffected, which is why the issue reproduced on one environment and not the other.

Root cause: `Order\Base::save_meta_value()` decided which fields to persist using the same field list that the bulk **modal** trims for display (`Bulk::additional_meta_box`). On the legacy list screen that trim removes every `show_in_bulk => false` field — including **Letterbox 48** (and ID Check). The injected Letterbox 48 selection was therefore never saved, so the label engine fell back to the Standard product and both the label and the order display flipped to Standard.

Fix: give `meta_box_fields()` a `$context` (`'display'` vs `'save'`) that is passed through the `postnl_order_meta_box_fields` filter. `Bulk::additional_meta_box()` now trims only for `'display'` and returns the full field set for `'save'`, so persistence can no longer drop a selected option. This keeps the display-trim behaviour of the bulk modal intact while making the save path storage-mode agnostic. Also fixes the same latent drop for ID Check on legacy bulk.

Relates to ClickUp task: https://app.clickup.com/t/4550855/868kdd9c0

Closes # .

### How to test the changes in this Pull Request:

1. On a store using **WordPress posts storage (legacy / HPOS off)**, set PostNL → *Default automatic letterboxparcel product* to **Letterboxparcel 48 hours**, and have a Letterbox-eligible product.
2. Place an order for that product (NL). Confirm it shows **Letterbox 48** in the orders list and in the order's *Label & Tracking* box.
3. From the classic Orders list, tick the order → bulk action **PostNL Create Label** → **Apply**.
4. Open the order: **Delivery Type stays "Letterboxparcel (48h)"** and the generated label is the Letterbox 48 product (2948) — **not** Standard Shipment. (Before this fix it reverted to Standard.)
5. Turn **HPOS on** and repeat 2–4 to confirm no regression on the new storage.
6. Confirm **24h Letterbox** and the **single-order "Create Label"** button are unchanged.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fixed Letterbox 48 shipments reverting to Standard Shipment when a label was generated via the bulk action on the classic (non-HPOS) orders list.
