### PR TITLE
22. V4 Returns service (return/generate)

### DIFF
--- a/src/Rest_API/Service_Factory.php
+++ b/src/Rest_API/Service_Factory.php
@@ -101,6 +101,17 @@ class Service_Factory {
 	private $label_v4_memo = null;
 
 	/**
+	 * Memoised self-built V4 returns service.
+	 *
+	 * Kept out of $v4_services for the same reason as $label_v4_memo: that array
+	 * means "a V4 service was explicitly injected for this flow", and giving it a
+	 * second meaning is how a later predicate reading it gets a wrong answer.
+	 *
+	 * @var V4_Returns_Service|null
+	 */
+	private $return_label_v4_memo = null;
+
+	/**
 	 * Service_Factory constructor.
 	 *
 	 * @param object|null $settings Plugin settings instance, or null when unavailable.
@@ -250,12 +261,25 @@ class Service_Factory {
 	 */
 	public function return_label_service(): Return_Label_Service_Interface {
 		if ( $this->should_use_v4( 'return_label' ) ) {
-			// A test double injected via inject_v4_service() wins; otherwise build the real V4 service,
-			// which handles the NL retailPrint return and falls back to the legacy pipeline for the rest.
-			if ( ! isset( $this->v4_services['return_label'] ) ) {
-				$this->v4_services['return_label'] = new V4_Returns_Service();
+			// A service injected via inject_v4_service() wins; otherwise build the real V4
+			// service, which handles the NL retailPrint return and falls back to the legacy
+			// pipeline for the rest.
+			if ( isset( $this->v4_services['return_label'] ) ) {
+				return $this->v4_services['return_label'];
 			}
-			return $this->v4_services['return_label'];
+			// Memoised apart from $v4_services for the same reason as label_service():
+			// that array means "deliberately injected", and barcode_from_label() reads it.
+			// Caching a self-built instance there would give the array two meanings, and
+			// the next predicate written against it would silently get the wrong answer.
+			if ( null === $this->return_label_v4_memo ) {
+				$logger                     = $this->v4_logger();
+				$this->return_label_v4_memo = new V4_Returns_Service(
+					new Client_Factory( $this->settings, $logger ),
+					(string) $this->settings->get_api_key_new(),
+					$logger
+				);
+			}
+			return $this->return_label_v4_memo;
 		}
 		if ( ! isset( $this->legacy_memos['return_label'] ) ) {
 			$this->legacy_memos['return_label'] = new Legacy_Return_Label_Service();

--- a/src/Rest_API/Service_Factory.php
+++ b/src/Rest_API/Service_Factory.php
@@ -27,6 +27,7 @@ use PostNLWooCommerce\Rest_API\Legacy\Smart_Returns_Service as Legacy_Smart_Retu
 use PostNLWooCommerce\Rest_API\SDK\Client_Factory;
 use PostNLWooCommerce\Rest_API\SDK\Logger_Adapter;
 use PostNLWooCommerce\Rest_API\V4\Label\Service as V4_Label_Service;
+use PostNLWooCommerce\Rest_API\V4\Returns\Service as V4_Returns_Service;
 use Psr\Log\LoggerInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -248,7 +249,12 @@ class Service_Factory {
 	 * @return Return_Label_Service_Interface
 	 */
 	public function return_label_service(): Return_Label_Service_Interface {
-		if ( $this->should_use_v4( 'return_label' ) && isset( $this->v4_services['return_label'] ) ) {
+		if ( $this->should_use_v4( 'return_label' ) ) {
+			// A test double injected via inject_v4_service() wins; otherwise build the real V4 service,
+			// which handles the NL retailPrint return and falls back to the legacy pipeline for the rest.
+			if ( ! isset( $this->v4_services['return_label'] ) ) {
+				$this->v4_services['return_label'] = new V4_Returns_Service();
+			}
 			return $this->v4_services['return_label'];
 		}
 		if ( ! isset( $this->legacy_memos['return_label'] ) ) {

--- a/src/Rest_API/V4/Returns/Request_Builder.php
+++ b/src/Rest_API/V4/Returns/Request_Builder.php
@@ -12,6 +12,7 @@ namespace PostNLWooCommerce\Rest_API\V4\Returns;
 use Postnl\Sdk\Enums\Payload\Country;
 use Postnl\Sdk\Enums\Payload\LabelOutputType;
 use Postnl\Sdk\Enums\Payload\LabelPrintMethod;
+use Postnl\Sdk\Enums\Payload\LabelResolution;
 use Postnl\Sdk\Enums\Payload\ShipmentType;
 use Postnl\Sdk\RequestData\V4\Address;
 use Postnl\Sdk\RequestData\V4\Contact;
@@ -68,7 +69,8 @@ class Request_Builder {
 	 *                                company, street, house_number, house_number_ext,
 	 *                                postcode, city, country.
 	 *     @type string $print_method LabelPrintMethod value, e.g. 'retailPrint'.
-	 *     @type array  $label        Label output: output_type (pdf|zpl|jpg|gif|png).
+	 *     @type array  $label        Label output: output_type (pdf|zpl|jpg|gif|png)
+	 *                                and resolution (200|300|600).
 	 *     @type string $barcode      Pre-issued return barcode to confirm; empty to let
 	 *                                the endpoint auto-issue one.
 	 *     @type string $reference    Merchant shipment reference (order number).
@@ -92,6 +94,7 @@ class Request_Builder {
 
 		$label_settings = new LabelSettings(
 			outputType: self::output_type( (string) ( $label_fields['output_type'] ?? 'pdf' ) ),
+			resolution: self::resolution( (int) ( $label_fields['resolution'] ?? 200 ) ),
 			printMethod: self::print_method( (string) ( $fields['print_method'] ?? 'retailPrint' ) )
 		);
 
@@ -178,6 +181,20 @@ class Request_Builder {
 	 */
 	private static function output_type( string $output_type ): LabelOutputType {
 		return LabelOutputType::tryFrom( strtolower( $output_type ) ) ?? LabelOutputType::PDF;
+	}
+
+	/**
+	 * Resolve a resolution integer into the SDK LabelResolution enum.
+	 *
+	 * The merchant's DPI setting offers 200, 300 and 600 and defaults to 600. The
+	 * SDK's own default is 200, so leaving this unset silently downgraded every
+	 * return label.
+	 *
+	 * @param int $resolution Print resolution in DPI.
+	 * @return LabelResolution
+	 */
+	private static function resolution( int $resolution ): LabelResolution {
+		return LabelResolution::tryFrom( $resolution ) ?? LabelResolution::DPI_200;
 	}
 
 	/**

--- a/src/Rest_API/V4/Returns/Request_Builder.php
+++ b/src/Rest_API/V4/Returns/Request_Builder.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Class Rest_API\V4\Returns\Request_Builder file.
+ *
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Rest_API\V4\Returns;
+
+use Postnl\Sdk\Enums\Payload\Country;
+use Postnl\Sdk\Enums\Payload\LabelOutputType;
+use Postnl\Sdk\Enums\Payload\LabelPrintMethod;
+use Postnl\Sdk\Enums\Payload\ShipmentType;
+use Postnl\Sdk\RequestData\V4\Address;
+use Postnl\Sdk\RequestData\V4\Contact;
+use Postnl\Sdk\RequestData\V4\CustomerReferences;
+use Postnl\Sdk\RequestData\V4\Dimensions;
+use Postnl\Sdk\RequestData\V4\LabelSettings;
+use Postnl\Sdk\RequestData\V4\ShipmentParty;
+use Postnl\Sdk\ResponseData\V4\ShippingItem;
+use Postnl\Sdk\Service\ReturnShipment\V4\Request\ReturnShipmentRequest;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Request_Builder
+ *
+ * Pure translator from a flat, already-parsed field array into a V4
+ * ReturnShipmentRequest DTO for the /shipment/delivery/v4/return/generate
+ * endpoint. It performs no WooCommerce or settings access, so the DTO shape can
+ * be asserted in isolation.
+ *
+ * Scope: the retail-print (retailPrint) NL flow. PostNL confirmed (2026-05-21)
+ * the three legacy return mechanisms collapse onto this one endpoint,
+ * differentiated by printMethod and the receiver address:
+ *
+ * - printMethod is retailPrint for NL-origin returns (consumerPrint is a
+ *   BE-origin follow-on, left unimplemented).
+ * - The sender is the consumer returning the item; the receiver is the merchant,
+ *   whose address encodes reply-number (Antwoordnummer) vs return-to-home.
+ * - returnPeriod is omitted (the V4 default is 35 days and PostNL do not want it
+ *   differentiated) and there are no additional services for return products, so
+ *   no ReturnOptions block is emitted.
+ *
+ * The merchant's customerNumber/customerCode are injected into the receiver by
+ * the SDK client (ClientBuilder::withCustomerCredentials), so they are
+ * deliberately absent here.
+ *
+ * @since   5.9.10
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+class Request_Builder {
+
+	/**
+	 * Build the ReturnShipmentRequest from parsed order/settings fields.
+	 *
+	 * @param array $fields {
+	 *     Flat, pre-parsed values.
+	 *
+	 *     @type array  $sender       Consumer returning the item: company, first_name,
+	 *                                last_name, street, house_number, house_number_ext,
+	 *                                postcode, city, country, email, phone.
+	 *     @type array  $receiver     Merchant return address (reply-number or home):
+	 *                                company, street, house_number, house_number_ext,
+	 *                                postcode, city, country.
+	 *     @type string $print_method LabelPrintMethod value, e.g. 'retailPrint'.
+	 *     @type array  $label        Label output: output_type (pdf|zpl|jpg|gif|png).
+	 *     @type string $barcode      Pre-issued return barcode to confirm; empty to let
+	 *                                the endpoint auto-issue one.
+	 *     @type string $reference    Merchant shipment reference (order number).
+	 *     @type int    $weight_gr    Total shipment weight in grams.
+	 * }
+	 * @return ReturnShipmentRequest
+	 */
+	public static function build( array $fields ): ReturnShipmentRequest {
+		$sender_fields   = $fields['sender'] ?? array();
+		$receiver_fields = $fields['receiver'] ?? array();
+		$label_fields    = $fields['label'] ?? array();
+
+		$sender = ShipmentParty::asReturnSender(
+			address: self::address( $sender_fields ),
+			contact: self::contact( $sender_fields )
+		);
+
+		$receiver = ShipmentParty::asReturnReceiver(
+			address: self::address( $receiver_fields )
+		);
+
+		$label_settings = new LabelSettings(
+			outputType: self::output_type( (string) ( $label_fields['output_type'] ?? 'pdf' ) ),
+			printMethod: self::print_method( (string) ( $fields['print_method'] ?? 'retailPrint' ) )
+		);
+
+		$item = new ShippingItem(
+			barcode: self::maybe_null( (string) ( $fields['barcode'] ?? '' ) ),
+			customerReferences: new CustomerReferences(
+				shipmentReference: self::maybe_null( (string) ( $fields['reference'] ?? '' ) )
+			),
+			dimensions: new Dimensions(
+				weightGr: max( 1, (int) ( $fields['weight_gr'] ?? 0 ) )
+			)
+		);
+
+		return new ReturnShipmentRequest(
+			sender: $sender,
+			receiver: $receiver,
+			labelSettings: $label_settings,
+			shipmentType: ShipmentType::Parcel,
+			items: array( $item )
+		);
+	}
+
+	/**
+	 * Translate an address field array into a V4 Address DTO.
+	 *
+	 * @param array $fields Address fields keyed as documented on build().
+	 * @return Address
+	 */
+	private static function address( array $fields ): Address {
+		return new Address(
+			countryIso: self::country( (string) ( $fields['country'] ?? '' ) ),
+			houseNumber: self::maybe_null( (string) ( $fields['house_number'] ?? '' ) ),
+			postalCode: self::maybe_null( (string) ( $fields['postcode'] ?? '' ) ),
+			companyName: self::maybe_null( (string) ( $fields['company'] ?? '' ) ),
+			street: self::maybe_null( (string) ( $fields['street'] ?? '' ) ),
+			houseNumberAddition: self::maybe_null( (string) ( $fields['house_number_ext'] ?? '' ) ),
+			city: self::maybe_null( (string) ( $fields['city'] ?? '' ) )
+		);
+	}
+
+	/**
+	 * Translate consumer contact fields into a V4 Contact DTO.
+	 *
+	 * @param array $fields Sender fields keyed as documented on build().
+	 * @return Contact
+	 */
+	private static function contact( array $fields ): Contact {
+		return new Contact(
+			email: self::maybe_null( (string) ( $fields['email'] ?? '' ) ),
+			firstName: self::maybe_null( (string) ( $fields['first_name'] ?? '' ) ),
+			lastName: self::maybe_null( (string) ( $fields['last_name'] ?? '' ) ),
+			mobileNumber: self::maybe_null( (string) ( $fields['phone'] ?? '' ) ),
+			companyName: self::maybe_null( (string) ( $fields['company'] ?? '' ) )
+		);
+	}
+
+	/**
+	 * Resolve a country code into the SDK Country enum, defaulting to NL.
+	 *
+	 * @param string $code Two-letter ISO country code.
+	 * @return Country
+	 */
+	private static function country( string $code ): Country {
+		return Country::tryFrom( strtoupper( $code ) ) ?? Country::NL;
+	}
+
+	/**
+	 * Resolve a print-method string into the SDK LabelPrintMethod enum.
+	 *
+	 * Defaults to retailPrint — the only method valid for the NL-origin flow.
+	 *
+	 * @param string $print_method LabelPrintMethod value, e.g. 'retailPrint'.
+	 * @return LabelPrintMethod
+	 */
+	private static function print_method( string $print_method ): LabelPrintMethod {
+		return LabelPrintMethod::tryFrom( $print_method ) ?? LabelPrintMethod::Retail;
+	}
+
+	/**
+	 * Resolve a label output-type string into the SDK LabelOutputType enum.
+	 *
+	 * @param string $output_type One of pdf|zpl|jpg|gif|png.
+	 * @return LabelOutputType
+	 */
+	private static function output_type( string $output_type ): LabelOutputType {
+		return LabelOutputType::tryFrom( strtolower( $output_type ) ) ?? LabelOutputType::PDF;
+	}
+
+	/**
+	 * Return null for an empty string so the DTO omits the field entirely.
+	 *
+	 * @param string $value Candidate value.
+	 * @return string|null
+	 */
+	private static function maybe_null( string $value ): ?string {
+		return '' === $value ? null : $value;
+	}
+}

--- a/src/Rest_API/V4/Returns/Response_Mapper.php
+++ b/src/Rest_API/V4/Returns/Response_Mapper.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Class Rest_API\V4\Returns\Response_Mapper file.
+ *
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Rest_API\V4\Returns;
+
+use Postnl\Sdk\ResponseData\V4\Label;
+use Postnl\Sdk\ResponseData\V4\ReturnShippingItem;
+use Postnl\Sdk\Service\ReturnShipment\V4\Response\GenerateReturnResponseInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Response_Mapper
+ *
+ * Pure reader for the return/generate response. Extracts the issued return
+ * barcode and the label document(s) without any WooCommerce or filesystem
+ * access, so barcode capture can be asserted in isolation. File writing and
+ * merging stay in the WooCommerce-bound service.
+ *
+ * @since   5.9.10
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+class Response_Mapper {
+
+	/**
+	 * Return the first return item from the response, or null when empty.
+	 *
+	 * @param GenerateReturnResponseInterface $response Response from return/generate.
+	 * @return ReturnShippingItem|null
+	 */
+	public static function first_return_item( GenerateReturnResponseInterface $response ): ?ReturnShippingItem {
+		$items = $response->items();
+
+		return $items->isEmpty() ? null : $items->first();
+	}
+
+	/**
+	 * Return the barcode issued for a return item.
+	 *
+	 * Prefers the item barcode, then the returnBarcode, then the supplied
+	 * fallback (used only when the response omits both).
+	 *
+	 * @param ReturnShippingItem $item     Return item from the response.
+	 * @param string             $fallback Barcode to use when none is returned.
+	 * @return string
+	 */
+	public static function get_barcode( ReturnShippingItem $item, string $fallback = '' ): string {
+		if ( null !== $item->barcode && '' !== $item->barcode ) {
+			return $item->barcode;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
+		if ( null !== $item->returnBarcode && '' !== $item->returnBarcode ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
+			return $item->returnBarcode;
+		}
+
+		return $fallback;
+	}
+
+	/**
+	 * Return the international partner barcode issued for a return item.
+	 *
+	 * @param ReturnShippingItem $item Return item from the response.
+	 * @return string
+	 */
+	public static function get_partner_barcode( ReturnShippingItem $item ): string {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
+		return null !== $item->partnerBarcode ? $item->partnerBarcode : '';
+	}
+
+	/**
+	 * Return the international partner id issued for a return item.
+	 *
+	 * @param ReturnShippingItem $item Return item from the response.
+	 * @return string
+	 */
+	public static function get_partner_id( ReturnShippingItem $item ): string {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
+		return null !== $item->partnerId ? $item->partnerId : '';
+	}
+
+	/**
+	 * Return the non-empty Label objects attached to a return item.
+	 *
+	 * @param ReturnShippingItem $item Return item from the response.
+	 * @return Label[]
+	 */
+	public static function get_labels( ReturnShippingItem $item ): array {
+		if ( null === $item->labels ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$item->labels->all(),
+				static function ( Label $label ): bool {
+					return ! $label->isEmpty();
+				}
+			)
+		);
+	}
+
+	/**
+	 * Decode a label's base64 document content.
+	 *
+	 * @param Label $label Label object from the response.
+	 * @return string Raw (decoded) label bytes, or empty string when absent.
+	 */
+	public static function decode_content( Label $label ): string {
+		if ( null === $label->label || '' === $label->label ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding a PostNL label document returned base64-encoded by the SDK.
+		$decoded = base64_decode( $label->label, true );
+
+		return false === $decoded ? '' : $decoded;
+	}
+
+	/**
+	 * Build a normalized return-label record matching the shape stored in
+	 * _postnl_order_metadata['labels']['return-label'] by the legacy path,
+	 * tagged as V4.
+	 *
+	 * @param string $barcode  Barcode for this return label.
+	 * @param string $filepath Absolute path to the written label file.
+	 * @return array{type:string,barcode:string,created_at:int,filepath:string,api_version:string}
+	 */
+	public static function to_label_record( string $barcode, string $filepath ): array {
+		return array(
+			'type'        => 'return-label',
+			'barcode'     => $barcode,
+			// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Mirrors the legacy label record's created_at timestamp stored in order meta.
+			'created_at'  => current_time( 'timestamp' ),
+			'filepath'    => $filepath,
+			'api_version' => 'v4',
+		);
+	}
+}

--- a/src/Rest_API/V4/Returns/Response_Mapper.php
+++ b/src/Rest_API/V4/Returns/Response_Mapper.php
@@ -67,28 +67,6 @@ class Response_Mapper {
 	}
 
 	/**
-	 * Return the international partner barcode issued for a return item.
-	 *
-	 * @param ReturnShippingItem $item Return item from the response.
-	 * @return string
-	 */
-	public static function get_partner_barcode( ReturnShippingItem $item ): string {
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
-		return null !== $item->partnerBarcode ? $item->partnerBarcode : '';
-	}
-
-	/**
-	 * Return the international partner id issued for a return item.
-	 *
-	 * @param ReturnShippingItem $item Return item from the response.
-	 * @return string
-	 */
-	public static function get_partner_id( ReturnShippingItem $item ): string {
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
-		return null !== $item->partnerId ? $item->partnerId : '';
-	}
-
-	/**
 	 * Return the non-empty Label objects attached to a return item.
 	 *
 	 * @param ReturnShippingItem $item Return item from the response.

--- a/src/Rest_API/V4/Returns/Service.php
+++ b/src/Rest_API/V4/Returns/Service.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace PostNLWooCommerce\Rest_API\V4\Returns;
 
 use Postnl\Sdk\Client\PostnlClientInterface;
+use Postnl\Sdk\Service\ReturnShipment\V4\Request\ReturnShipmentRequest;
 use Postnl\Sdk\Service\ReturnShipment\V4\Response\GenerateReturnResponseInterface;
 use PostNLWooCommerce\Order\Base as Order_Base;
 use PostNLWooCommerce\Rest_API\Contracts\Return_Label_Service_Interface;
@@ -17,7 +18,9 @@ use PostNLWooCommerce\Rest_API\Legacy\Return_Label\Item_Info;
 use PostNLWooCommerce\Rest_API\Legacy\Return_Label_Service as Legacy_Return_Label_Service;
 use PostNLWooCommerce\Rest_API\SDK\Client_Factory;
 use PostNLWooCommerce\Rest_API\SDK\Exception_Converter;
+use PostNLWooCommerce\Rest_API\V4\Label\Request_Builder as Label_Request_Builder;
 use PostNLWooCommerce\Utils;
+use Psr\Log\LoggerInterface;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -31,9 +34,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * result in the same _postnl_order_metadata['labels']['return-label'] shape as
  * the legacy path, tagged api_version = v4.
  *
- * Scope: the retailPrint NL flow (the live NL return mechanism). A non-NL origin
- * — consumerPrint is a BE-origin follow-on — falls back to the untouched legacy
- * pipeline. activate() is unchanged: it still calls the V1
+ * Scope: the retailPrint NL flow (the live NL return mechanism). The print method
+ * follows the country the parcel is handed in from, which is the customer's, so a
+ * return from a Belgian customer is a consumerPrint return; that is a follow-on and
+ * is not implemented, and those orders fall back to the untouched legacy pipeline.
+ * activate() is unchanged: it still calls the V1
  * /parcels/v1/shipment/activatereturn endpoint via the legacy service, since
  * that operation is not part of the return/generate migration. Because both
  * gates (a validated V4 key and the per-flow flag) default off, merging this
@@ -48,20 +53,56 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Service extends Order_Base implements Return_Label_Service_Interface {
 
 	/**
-	 * SDK client factory. Injected in tests; built from settings otherwise.
+	 * SDK client factory.
 	 *
-	 * @var Client_Factory|null
+	 * @var Client_Factory
 	 */
 	private $client_factory;
 
 	/**
+	 * Resolved PostNL V4 API key.
+	 *
+	 * @var string
+	 */
+	private $v4_key;
+
+	/**
+	 * PSR-3 logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * Service constructor.
 	 *
-	 * @param Client_Factory|null $client_factory Optional SDK client factory.
+	 * The API key and the logger are both required rather than defaulted, matching
+	 * V4\Label\Service, V4\Timeframe\Service and V4\Pickup_Location\Service: the key
+	 * is resolved and validated by the caller that already decides whether V4 may run
+	 * at all (Service_Factory::has_v4_key()), so re-deriving it here would duplicate
+	 * that decision behind a fallback that silently sends an empty key; and a
+	 * defaulted NullLogger would let a caller wire the service up with logging
+	 * switched off — the exact gap this parameter closes.
+	 *
+	 * The key is marked SensitiveParameter so PHP redacts it from stack traces,
+	 * matching Client_Factory::build().
+	 *
+	 * @since 6.0.0 Requires the resolved API key and a PSR-3 logger.
+	 *
+	 * @param Client_Factory  $client_factory SDK client factory.
+	 * @param string          $v4_key         PostNL V4 API key.
+	 * @param LoggerInterface $logger         PSR-3 logger; wiring passes a Logger_Adapter.
 	 */
-	public function __construct( ?Client_Factory $client_factory = null ) {
+	public function __construct(
+		Client_Factory $client_factory,
+		#[\SensitiveParameter]
+		string $v4_key,
+		LoggerInterface $logger
+	) {
 		parent::__construct();
 		$this->client_factory = $client_factory;
+		$this->v4_key         = $v4_key;
+		$this->logger         = $logger;
 	}
 
 	/**
@@ -86,27 +127,71 @@ class Service extends Order_Base implements Return_Label_Service_Interface {
 	 * @throws \Exception If the SDK request fails (converted to the legacy error shape).
 	 */
 	public function create( array $post_data ): array {
-		$item_info = new Item_Info( $post_data );
-
-		// Mirror the legacy pipeline guard: a return label is only created when the
-		// merchant selected it. The pipeline returns an empty array in that case.
-		if ( 'yes' !== ( $post_data['saved_data']['backend']['create_return_label'] ?? '' )
-			|| ! $this->is_eligible( $item_info ) ) {
+		// Checked before Item_Info is built, matching the legacy pipeline
+		// (Order\Base::maybe_create_return_label_pipeline()). Item_Info extends
+		// Shipping\Item_Info, which lists main_barcode as required with no default and
+		// throws "Barcode is empty!" when it is absent — and main_barcode is never set
+		// on the harvest path, where the label response issues the barcode. Building it
+		// first would turn "the merchant did not ask for a return label" into an error
+		// about barcodes on an ordinary save.
+		if ( 'yes' !== ( $post_data['saved_data']['backend']['create_return_label'] ?? '' ) ) {
 			return $this->maybe_create_return_label_pipeline( $post_data );
 		}
 
-		$fields  = $this->extract_fields( $item_info, $post_data );
-		$request = Request_Builder::build( $fields );
+		$item_info = new Item_Info( $post_data );
 
+		if ( ! $this->is_eligible( $item_info ) ) {
+			return $this->maybe_create_return_label_pipeline( $post_data );
+		}
+
+		$fields   = $this->extract_fields( $item_info, $post_data );
+		$request  = Request_Builder::build( $fields );
+		$response = $this->generate_return( $request, $fields );
+
+		return $this->store_labels( $response, $post_data['order'], (string) $fields['barcode'] );
+	}
+
+	/**
+	 * Send the return/generate request, converting and logging any SDK failure.
+	 *
+	 * Kept apart from create() so the transport and its error handling can be
+	 * exercised without a WooCommerce order, matching V4\Label\Service::confirm_label().
+	 *
+	 * @param ReturnShipmentRequest $request Built request DTO.
+	 * @param array                 $fields  Flattened fields, read for the log reference.
+	 *
+	 * @return GenerateReturnResponseInterface
+	 *
+	 * @throws \Exception Converted SDK error when the request fails.
+	 */
+	protected function generate_return( ReturnShipmentRequest $request, array $fields ): GenerateReturnResponseInterface {
 		try {
-			$response = $this->build_client()->returns()->generateReturn( $request );
+			return $this->build_client()->returns()->generateReturn( $request );
 		} catch ( \Throwable $exception ) {
+			// Exception_Converter returns a plugin-shaped \Exception; its message can
+			// carry raw API text (field errors, upstream messages) — escape on output.
 			$error = Exception_Converter::convert( $exception );
+
+			// The converted message is deliberately merchant-safe, and one of its
+			// variants tells the reader to check these very logs, so the original SDK
+			// failure has to be written here — nothing else reads getPrevious().
+			//
+			// The shipment reference is the merchant's own order number: it is what
+			// makes the entry traceable back to an order, and it is store-internal
+			// rather than customer-identifying, so it is kept where the address is not.
+			$this->logger->error(
+				sprintf(
+					'V4 return label creation failed for order "%1$s": %2$s (cause: %3$s: %4$s)',
+					(string) ( $fields['reference'] ?? '' ),
+					$error->getMessage(),
+					get_class( $exception ),
+					$exception->getMessage()
+				)
+			);
+
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception_Converter returns an already-escaped, translated message.
 			throw $error;
 		}
-
-		return $this->store_labels( $response, $post_data['order'], (string) $fields['barcode'] );
 	}
 
 	/**
@@ -126,14 +211,28 @@ class Service extends Order_Base implements Return_Label_Service_Interface {
 	/**
 	 * Decide whether an order's return is the NL retailPrint flow this service handles.
 	 *
-	 * Only NL-origin returns use retailPrint; a BE origin (consumerPrint) is not
-	 * yet implemented and falls back to legacy.
+	 * The print method depends on where the parcel is handed in, which is the
+	 * customer's country, not the store's. The SDK states it on LabelPrintMethod:
+	 * "Sending the return from BE means only consumer is available. Sending from NL
+	 * means only retail is available." So a Dutch store shipping to a Belgian
+	 * customer is a consumerPrint return, and consumerPrint is a follow-on that is
+	 * not implemented — those fall back to the untouched legacy pipeline.
+	 *
+	 * Reading the store address here instead would always be true, because the
+	 * plugin refuses to run unless the store is in NL or BE. Mapping::
+	 * option_available_list() does offer create_return_label for NL to BE, so
+	 * Belgian customers reach this method in practice.
+	 *
+	 * Restricting to NL customers also keeps the merge step safe: the stored record
+	 * is typed 'return-label', and Mapping::label_type_list() only lists that type
+	 * for NL to NL and NL to BE, so an EU or ROW destination would leave
+	 * Order\Base::maybe_merge_labels() with no files to merge.
 	 *
 	 * @param Item_Info $item_info Parsed legacy return item info.
 	 * @return bool
 	 */
 	private function is_eligible( Item_Info $item_info ): bool {
-		return 'NL' === (string) ( $item_info->shipper['country'] ?? '' );
+		return 'NL' === (string) ( $item_info->receiver['country'] ?? '' );
 	}
 
 	/**
@@ -176,29 +275,14 @@ class Service extends Order_Base implements Return_Label_Service_Interface {
 			'barcode'      => (string) ( $post_data['return_barcode'] ?? '' ),
 			'reference'    => (string) ( $item_info->shipment['order_number'] ?? '' ),
 			'weight_gr'    => (int) ( $item_info->shipment['total_weight'] ?? 0 ),
-			'label'        => array(
-				'output_type' => $this->resolve_output_type( (string) ( $item_info->shipment['printer_type'] ?? '' ) ),
+			// Shared with the outbound label path on purpose. The merchant's setting is
+			// one combined string such as 'Zebra|Generic ZPL II 600 dpi', and V4 wants
+			// the format and the resolution as separate fields. Splitting it here as
+			// well would drop the dpi half, which is what this method used to do.
+			'label'        => Label_Request_Builder::printer_type_to_label_settings(
+				(string) ( $item_info->shipment['printer_type'] ?? '' )
 			),
 		);
-	}
-
-	/**
-	 * Resolve the merchant's combined printer-type string to a discrete output type.
-	 *
-	 * PostNL advises PNG/JPG for retailPrint, but the merchant's configured format
-	 * is respected; PDF is the fallback.
-	 *
-	 * @param string $printer_type Legacy combined printer-type string.
-	 * @return string
-	 */
-	private function resolve_output_type( string $printer_type ): string {
-		foreach ( array( 'zpl', 'jpg', 'gif', 'png', 'pdf' ) as $candidate ) {
-			if ( false !== stripos( $printer_type, $candidate ) ) {
-				return $candidate;
-			}
-		}
-
-		return 'pdf';
 	}
 
 	/**
@@ -207,13 +291,7 @@ class Service extends Order_Base implements Return_Label_Service_Interface {
 	 * @return PostnlClientInterface
 	 */
 	private function build_client(): PostnlClientInterface {
-		$factory = $this->client_factory ?? new Client_Factory( $this->settings );
-
-		$v4_key = method_exists( $this->settings, 'get_api_key_new' )
-			? (string) $this->settings->get_api_key_new()
-			: '';
-
-		return $factory->build( $v4_key, (bool) $this->settings->is_sandbox() );
+		return $this->client_factory->build( $this->v4_key, (bool) $this->settings->is_sandbox() );
 	}
 
 	/**

--- a/src/Rest_API/V4/Returns/Service.php
+++ b/src/Rest_API/V4/Returns/Service.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Class Rest_API\V4\Returns\Service file.
+ *
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Rest_API\V4\Returns;
+
+use Postnl\Sdk\Client\PostnlClientInterface;
+use Postnl\Sdk\Service\ReturnShipment\V4\Response\GenerateReturnResponseInterface;
+use PostNLWooCommerce\Order\Base as Order_Base;
+use PostNLWooCommerce\Rest_API\Contracts\Return_Label_Service_Interface;
+use PostNLWooCommerce\Rest_API\Legacy\Return_Label\Item_Info;
+use PostNLWooCommerce\Rest_API\Legacy\Return_Label_Service as Legacy_Return_Label_Service;
+use PostNLWooCommerce\Rest_API\SDK\Client_Factory;
+use PostNLWooCommerce\Rest_API\SDK\Exception_Converter;
+use PostNLWooCommerce\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Service
+ *
+ * V4 SDK implementation of the return-label flow. It generates a return label
+ * through the /shipment/delivery/v4/return/generate endpoint and stores the
+ * result in the same _postnl_order_metadata['labels']['return-label'] shape as
+ * the legacy path, tagged api_version = v4.
+ *
+ * Scope: the retailPrint NL flow (the live NL return mechanism). A non-NL origin
+ * — consumerPrint is a BE-origin follow-on — falls back to the untouched legacy
+ * pipeline. activate() is unchanged: it still calls the V1
+ * /parcels/v1/shipment/activatereturn endpoint via the legacy service, since
+ * that operation is not part of the return/generate migration. Because both
+ * gates (a validated V4 key and the per-flow flag) default off, merging this
+ * changes nothing for merchants.
+ *
+ * Extends Order\Base to reuse the put/merge helpers and the legacy pipeline for
+ * the fallback, mirroring Legacy\Return_Label_Service and V4\Label\Service.
+ *
+ * @since   5.9.10
+ * @package PostNLWooCommerce\Rest_API\V4\Returns
+ */
+class Service extends Order_Base implements Return_Label_Service_Interface {
+
+	/**
+	 * SDK client factory. Injected in tests; built from settings otherwise.
+	 *
+	 * @var Client_Factory|null
+	 */
+	private $client_factory;
+
+	/**
+	 * Service constructor.
+	 *
+	 * @param Client_Factory|null $client_factory Optional SDK client factory.
+	 */
+	public function __construct( ?Client_Factory $client_factory = null ) {
+		parent::__construct();
+		$this->client_factory = $client_factory;
+	}
+
+	/**
+	 * No WP hooks are registered by this service class.
+	 *
+	 * Required by Order\Base but intentionally a no-op here.
+	 */
+	public function init_hooks() {
+		// Intentionally empty — this service does not register WordPress hooks.
+	}
+
+	/**
+	 * Create a return label and return the normalized label record.
+	 *
+	 * Routes the NL retailPrint return to the V4 SDK; a non-NL origin runs the
+	 * untouched legacy pipeline.
+	 *
+	 * @param array $post_data Context needed to build and send the return request.
+	 *
+	 * @return array Normalized label record keyed by 'return-label'.
+	 *
+	 * @throws \Exception If the SDK request fails (converted to the legacy error shape).
+	 */
+	public function create( array $post_data ): array {
+		$item_info = new Item_Info( $post_data );
+
+		if ( ! $this->is_eligible( $item_info ) ) {
+			return $this->maybe_create_return_label_pipeline( $post_data );
+		}
+
+		$fields  = $this->extract_fields( $item_info, $post_data );
+		$request = Request_Builder::build( $fields );
+
+		try {
+			$response = $this->build_client()->returns()->generateReturn( $request );
+		} catch ( \Throwable $exception ) {
+			$error = Exception_Converter::convert( $exception );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception_Converter returns an already-escaped, translated message.
+			throw $error;
+		}
+
+		return $this->store_labels( $response, $post_data['order'], (string) $fields['barcode'] );
+	}
+
+	/**
+	 * Activate the return function on an existing outbound shipment.
+	 *
+	 * Unchanged by the return/generate migration — delegates to the legacy
+	 * service, which calls the V1 /parcels/v1/shipment/activatereturn endpoint.
+	 *
+	 * @param int $order_id WooCommerce order ID.
+	 * @return array JSON-decoded PostNL activatereturn response body.
+	 * @throws \Exception If the API request fails at transport level.
+	 */
+	public function activate( int $order_id ): array {
+		return ( new Legacy_Return_Label_Service() )->activate( $order_id );
+	}
+
+	/**
+	 * Decide whether an order's return is the NL retailPrint flow this service handles.
+	 *
+	 * Only NL-origin returns use retailPrint; a BE origin (consumerPrint) is not
+	 * yet implemented and falls back to legacy.
+	 *
+	 * @param Item_Info $item_info Parsed legacy return item info.
+	 * @return bool
+	 */
+	private function is_eligible( Item_Info $item_info ): bool {
+		return 'NL' === (string) ( $item_info->shipper['country'] ?? '' );
+	}
+
+	/**
+	 * Flatten the parsed item info into the field array Request_Builder consumes.
+	 *
+	 * The sender is the consumer returning the item (the order's shipping
+	 * recipient); the receiver is the merchant return address, already resolved by
+	 * Item_Info to the reply-number (Antwoordnummer) or return-to-home variant per
+	 * Settings::is_return_to_home_enabled().
+	 *
+	 * @param Item_Info $item_info Parsed legacy return item info.
+	 * @param array     $post_data Original return post data.
+	 * @return array
+	 */
+	private function extract_fields( Item_Info $item_info, array $post_data ): array {
+		return array(
+			'sender'       => array(
+				'company'          => $item_info->receiver['company'] ?? '',
+				'first_name'       => $item_info->receiver['first_name'] ?? '',
+				'last_name'        => $item_info->receiver['last_name'] ?? '',
+				'street'           => $item_info->receiver['address_1'] ?? '',
+				'house_number'     => $item_info->receiver['house_number'] ?? '',
+				'house_number_ext' => $item_info->receiver['address_2'] ?? '',
+				'postcode'         => $item_info->receiver['postcode'] ?? '',
+				'city'             => $item_info->receiver['city'] ?? '',
+				'country'          => $item_info->receiver['country'] ?? '',
+				'email'            => $item_info->shipment['email'] ?? '',
+				'phone'            => $item_info->shipment['phone'] ?? '',
+			),
+			'receiver'     => array(
+				'company'          => $item_info->customer['return_company'] ?? '',
+				'street'           => $item_info->customer['return_address_1'] ?? '',
+				'house_number'     => $item_info->customer['return_address_2'] ?? '',
+				'house_number_ext' => '',
+				'postcode'         => $item_info->customer['return_address_zip'] ?? '',
+				'city'             => $item_info->customer['return_address_city'] ?? '',
+				'country'          => $item_info->shipper['country'] ?? 'NL',
+			),
+			'print_method' => 'retailPrint',
+			'barcode'      => (string) ( $post_data['return_barcode'] ?? '' ),
+			'reference'    => (string) ( $item_info->shipment['order_number'] ?? '' ),
+			'weight_gr'    => (int) ( $item_info->shipment['total_weight'] ?? 0 ),
+			'label'        => array(
+				'output_type' => $this->resolve_output_type( (string) ( $item_info->shipment['printer_type'] ?? '' ) ),
+			),
+		);
+	}
+
+	/**
+	 * Resolve the merchant's combined printer-type string to a discrete output type.
+	 *
+	 * PostNL advises PNG/JPG for retailPrint, but the merchant's configured format
+	 * is respected; PDF is the fallback.
+	 *
+	 * @param string $printer_type Legacy combined printer-type string.
+	 * @return string
+	 */
+	private function resolve_output_type( string $printer_type ): string {
+		foreach ( array( 'zpl', 'jpg', 'gif', 'png', 'pdf' ) as $candidate ) {
+			if ( false !== stripos( $printer_type, $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return 'pdf';
+	}
+
+	/**
+	 * Build the configured SDK client for the current environment.
+	 *
+	 * @return PostnlClientInterface
+	 */
+	private function build_client(): PostnlClientInterface {
+		$factory = $this->client_factory ?? new Client_Factory( $this->settings );
+
+		$v4_key = method_exists( $this->settings, 'get_api_key_new' )
+			? (string) $this->settings->get_api_key_new()
+			: '';
+
+		return $factory->build( $v4_key, (bool) $this->settings->is_sandbox() );
+	}
+
+	/**
+	 * Write the return/generate response label(s) to disk and normalize them.
+	 *
+	 * Reuses Order\Base::maybe_merge_labels() so the A4/A6 handling matches the
+	 * legacy path, then re-tags the merged record as V4.
+	 *
+	 * @param GenerateReturnResponseInterface $response         return/generate response.
+	 * @param \WC_Order                       $order            WooCommerce order.
+	 * @param string                          $fallback_barcode Barcode to use if the response omits one.
+	 * @return array
+	 * @throws \Exception When the response carries no return item or no label content.
+	 */
+	private function store_labels( GenerateReturnResponseInterface $response, $order, string $fallback_barcode ): array {
+		$item = Response_Mapper::first_return_item( $response );
+
+		if ( null === $item ) {
+			throw new \Exception(
+				esc_html__( 'Cannot create the return label. No shipment was returned by PostNL.', 'postnl-for-woocommerce' )
+			);
+		}
+
+		$barcode = Response_Mapper::get_barcode( $item, $fallback_barcode );
+		$records = array();
+
+		foreach ( Response_Mapper::get_labels( $item ) as $label ) {
+			$content = Response_Mapper::decode_content( $label );
+
+			if ( '' === $content ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Third-party SDK DTO property.
+			$output_type = null !== $label->outputType ? $label->outputType->value : 'pdf';
+
+			$filename = Utils::generate_label_name( $order->get_id(), 'return-label', $barcode, 'A6', $output_type );
+			$filepath = trailingslashit( POSTNL_UPLOADS_DIR ) . $filename;
+
+			$this->write_label_file( $filepath, $content );
+
+			// Only record a label that actually exists on disk, so a failed write
+			// never persists a meta entry pointing at a missing file.
+			if ( ! is_file( $filepath ) ) {
+				continue;
+			}
+
+			$records[] = Response_Mapper::to_label_record( $barcode, $filepath );
+		}
+
+		if ( empty( $records ) ) {
+			throw new \Exception(
+				esc_html__( 'Cannot create the return label. Label content is missing', 'postnl-for-woocommerce' )
+			);
+		}
+
+		$labels = $this->maybe_merge_labels( $records, $order, $barcode, 'return-label' );
+
+		foreach ( array_keys( $labels ) as $key ) {
+			$labels[ $key ]['api_version'] = 'v4';
+		}
+
+		return $labels;
+	}
+
+	/**
+	 * Write a decoded label document to disk, creating the uploads dir as needed.
+	 *
+	 * A pre-existing file is left untouched. Failure is intentionally silent —
+	 * store_labels() verifies the file exists afterwards and skips the record if
+	 * it does not.
+	 *
+	 * @param string $filepath Absolute destination path.
+	 * @param string $content  Raw (decoded) label bytes.
+	 * @return void
+	 */
+	private function write_label_file( string $filepath, string $content ): void {
+		if ( is_file( $filepath ) ) {
+			return;
+		}
+
+		if ( ! wp_mkdir_p( POSTNL_UPLOADS_DIR ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Binary label bytes; mirrors Order\Base::put_label_content().
+		file_put_contents( $filepath, $content );
+	}
+}

--- a/src/Rest_API/V4/Returns/Service.php
+++ b/src/Rest_API/V4/Returns/Service.php
@@ -88,7 +88,10 @@ class Service extends Order_Base implements Return_Label_Service_Interface {
 	public function create( array $post_data ): array {
 		$item_info = new Item_Info( $post_data );
 
-		if ( ! $this->is_eligible( $item_info ) ) {
+		// Mirror the legacy pipeline guard: a return label is only created when the
+		// merchant selected it. The pipeline returns an empty array in that case.
+		if ( 'yes' !== ( $post_data['saved_data']['backend']['create_return_label'] ?? '' )
+			|| ! $this->is_eligible( $item_info ) ) {
 			return $this->maybe_create_return_label_pipeline( $post_data );
 		}
 

--- a/tests/php/unit/Rest_API/Service_FactoryTest.php
+++ b/tests/php/unit/Rest_API/Service_FactoryTest.php
@@ -23,6 +23,7 @@ use PostNLWooCommerce\Rest_API\Legacy\Postcode_Check_Service as Legacy_Postcode_
 use PostNLWooCommerce\Rest_API\Legacy\Smart_Returns_Service as Legacy_Smart_Returns_Service;
 use PostNLWooCommerce\Rest_API\Service_Factory;
 use PostNLWooCommerce\Rest_API\V4\Label\Service as V4_Label_Service;
+use PostNLWooCommerce\Rest_API\V4\Returns\Service as V4_Returns_Service;
 use PostNLWooCommerce\Tests\UnitTestCase;
 
 /**
@@ -693,5 +694,72 @@ class Service_FactoryTest extends UnitTestCase {
 
 		$this->assertSame( $injected, $factory->label_service() );
 		$this->assertTrue( $factory->barcode_from_label() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario 10 — the self-built V4 returns service must not masquerade as injected
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @testdox return_label_service() returns the real V4 returns service when the flag is on
+	 */
+	public function test_return_label_service_builds_v4_service_when_flag_on(): void {
+		Filters\expectApplied( 'postnl_sdk_enable_return_label' )->andReturn( true );
+
+		$factory = new Service_Factory( $this->settings_with_key() );
+
+		$this->assertInstanceOf( V4_Returns_Service::class, $factory->return_label_service() );
+	}
+
+	/**
+	 * @testdox return_label_service() memoizes the self-built V4 service across repeated calls
+	 */
+	public function test_return_label_service_memoizes_self_built_v4_service(): void {
+		Filters\expectApplied( 'postnl_sdk_enable_return_label' )->andReturn( true );
+
+		$factory = new Service_Factory( $this->settings_with_key() );
+
+		$this->assertSame( $factory->return_label_service(), $factory->return_label_service() );
+	}
+
+	/**
+	 * @testdox Calling return_label_service() leaves the injected-service store untouched
+	 *
+	 * $v4_services means "a V4 service was deliberately injected for this flow", and
+	 * barcode_from_label() reads it to decide whether Order\Base may skip the barcode
+	 * prefetch. Writing a lazily self-built instance into that array gives it a second
+	 * meaning, which is how the label flow crashed bulk runs from the second order on.
+	 * The returns service keeps its own memo for the same reason.
+	 */
+	public function test_return_label_service_call_does_not_register_as_injected(): void {
+		Filters\expectApplied( 'postnl_sdk_enable_return_label' )->andReturn( true );
+
+		$factory = new Service_Factory( $this->settings_with_key() );
+		$factory->return_label_service();
+
+		$store = new \ReflectionProperty( Service_Factory::class, 'v4_services' );
+		$store->setAccessible( true );
+
+		$this->assertArrayNotHasKey(
+			'return_label',
+			$store->getValue( $factory ),
+			'Self-building the V4 returns service must not register it as an injected service.'
+		);
+	}
+
+	/**
+	 * @testdox An injected V4 returns service still wins after the self-built one was created
+	 */
+	public function test_injected_v4_returns_service_wins_after_self_build(): void {
+		Filters\expectApplied( 'postnl_sdk_enable_return_label' )->andReturn( true );
+
+		$factory   = new Service_Factory( $this->settings_with_key() );
+		$self_built = $factory->return_label_service();
+
+		$injected = $this->make_return_label_stub();
+		$factory->inject_v4_service( 'return_label', $injected );
+
+		$this->assertNotSame( $self_built, $factory->return_label_service() );
+		$this->assertSame( $injected, $factory->return_label_service() );
 	}
 }

--- a/tests/php/unit/Rest_API/V4/Returns/Request_BuilderTest.php
+++ b/tests/php/unit/Rest_API/V4/Returns/Request_BuilderTest.php
@@ -55,7 +55,10 @@ class Request_BuilderTest extends UnitTestCase {
 			'reference'    => 'ORDER-1001',
 			'weight_gr'    => 1500,
 			'label'        => array(
-				'output_type' => 'jpg',
+				// Deliberately uppercase: the builder lowercases before resolving, and an
+				// already-lowercase fixture would let that call be deleted unnoticed.
+				'output_type' => 'JPG',
+				'resolution'  => 600,
 			),
 		);
 	}
@@ -125,6 +128,74 @@ class Request_BuilderTest extends UnitTestCase {
 		$fields['print_method'] = 'nonsense';
 
 		$this->assertSame( LabelPrintMethod::Retail->value, $this->payload( $fields )['labelSettings']['printMethod'] );
+	}
+
+	/**
+	 * @testdox build() passes a recognised print method through instead of defaulting.
+	 *
+	 * Pairs with test_print_method_defaults_to_retail(). On its own that test proves
+	 * nothing, because the happy-path fixture also resolves to Retail — so a resolver
+	 * hardcoded to Retail would satisfy both. consumerPrint is the only other value
+	 * the SDK enum accepts, so this is what makes the fallback real.
+	 */
+	public function test_known_print_method_is_passed_through(): void {
+		$fields                 = $this->return_fields();
+		$fields['print_method'] = 'consumerPrint';
+
+		$this->assertSame( LabelPrintMethod::Consumer->value, $this->payload( $fields )['labelSettings']['printMethod'] );
+	}
+
+	/**
+	 * @testdox build() reads the country from the input and uppercases it.
+	 *
+	 * Every other fixture uses 'NL', which is also the fallback and is already
+	 * uppercase, so both the lookup and the uppercasing could be deleted without any
+	 * test noticing. A lowercase non-NL country exercises both at once.
+	 */
+	public function test_country_is_read_from_input_and_uppercased(): void {
+		$fields                       = $this->return_fields();
+		$fields['sender']['country']  = 'be';
+
+		$this->assertSame( 'BE', $this->payload( $fields )['sender']['address']['countryIso'] );
+	}
+
+	/**
+	 * @testdox build() sends the merchant's print resolution rather than the SDK default.
+	 *
+	 * The DPI setting offers 200, 300 and 600 and defaults to 600, while the SDK's
+	 * own LabelSettings default is 200. Omitting the field silently downgraded every
+	 * return label, so the fixture uses 600 to keep the two apart.
+	 */
+	public function test_resolution_is_sent(): void {
+		$this->assertSame( 600, $this->payload( $this->return_fields() )['labelSettings']['resolution'] );
+
+		$fields                        = $this->return_fields();
+		$fields['label']['resolution'] = 300;
+		$this->assertSame( 300, $this->payload( $fields )['labelSettings']['resolution'] );
+	}
+
+	/**
+	 * @testdox build() falls back to 200 DPI for a resolution the SDK does not accept.
+	 */
+	public function test_unknown_resolution_falls_back_to_200(): void {
+		$fields                        = $this->return_fields();
+		$fields['label']['resolution'] = 150;
+
+		$this->assertSame( 200, $this->payload( $fields )['labelSettings']['resolution'] );
+	}
+
+	/**
+	 * @testdox build() carries every consumer contact field, not just the email.
+	 *
+	 * These reach the return label and drive track-and-trace notifications. Only the
+	 * email was asserted, so the other three could be dropped silently.
+	 */
+	public function test_sender_contact_carries_every_field(): void {
+		$contact = $this->payload( $this->return_fields() )['sender']['contact'];
+
+		$this->assertSame( 'Jan', $contact['firstName'] );
+		$this->assertSame( 'Jansen', $contact['lastName'] );
+		$this->assertSame( '0612345678', $contact['mobileNumber'] );
 	}
 
 	/**

--- a/tests/php/unit/Rest_API/V4/Returns/Request_BuilderTest.php
+++ b/tests/php/unit/Rest_API/V4/Returns/Request_BuilderTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Unit tests for Rest_API\V4\Returns\Request_Builder.
+ *
+ * @package PostNLWooCommerce\Tests\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Tests\Rest_API\V4\Returns;
+
+use Postnl\Sdk\Enums\Payload\LabelPrintMethod;
+use Postnl\Sdk\Enums\Payload\ShipmentType;
+use Postnl\Sdk\Service\ReturnShipment\V4\Request\ReturnShipmentRequest;
+use Postnl\Sdk\Support\PayloadMapper;
+use PostNLWooCommerce\Rest_API\V4\Returns\Request_Builder;
+use PostNLWooCommerce\Tests\UnitTestCase;
+
+/**
+ * @covers \PostNLWooCommerce\Rest_API\V4\Returns\Request_Builder
+ */
+class Request_BuilderTest extends UnitTestCase {
+
+	/**
+	 * A representative NL retailPrint return field set with a return-to-home receiver.
+	 *
+	 * @return array
+	 */
+	private function return_fields(): array {
+		return array(
+			'sender'       => array(
+				'company'          => '',
+				'first_name'       => 'Jan',
+				'last_name'        => 'Jansen',
+				'street'           => 'Main Street',
+				'house_number'     => '9',
+				'house_number_ext' => 'A',
+				'postcode'         => '1234AB',
+				'city'             => 'Amsterdam',
+				'country'          => 'NL',
+				'email'            => 'buyer@example.com',
+				'phone'            => '0612345678',
+			),
+			'receiver'     => array(
+				'company'          => 'My Shop',
+				'street'           => 'Siriusdreef',
+				'house_number'     => '42',
+				'house_number_ext' => '',
+				'postcode'         => '2132WT',
+				'city'             => 'Hoofddorp',
+				'country'          => 'NL',
+			),
+			'print_method' => 'retailPrint',
+			'barcode'      => '3SDEVCRET123',
+			'reference'    => 'ORDER-1001',
+			'weight_gr'    => 1500,
+			'label'        => array(
+				'output_type' => 'jpg',
+			),
+		);
+	}
+
+	/**
+	 * A reply-number (Antwoordnummer) receiver field set.
+	 *
+	 * @return array
+	 */
+	private function reply_number_fields(): array {
+		$fields             = $this->return_fields();
+		$fields['receiver'] = array(
+			'company'          => 'My Shop',
+			'street'           => 'Antwoordnummer',
+			'house_number'     => '12345',
+			'house_number_ext' => '',
+			'postcode'         => '1000AA',
+			'city'             => 'Amsterdam',
+			'country'          => 'NL',
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * Serialize the built request to its wire array.
+	 *
+	 * @param array $fields Builder input.
+	 * @return array
+	 */
+	private function payload( array $fields ): array {
+		$request = Request_Builder::build( $fields );
+		$this->assertInstanceOf( ReturnShipmentRequest::class, $request );
+
+		return $request->toArray( PayloadMapper::create() );
+	}
+
+	/**
+	 * @testdox build() produces a retailPrint parcel return with return sender and receiver.
+	 */
+	public function test_builds_retail_print_return(): void {
+		$payload = $this->payload( $this->return_fields() );
+
+		$this->assertSame( 'parcel', $payload['shipmentType'] );
+		$this->assertSame( LabelPrintMethod::Retail->value, $payload['labelSettings']['printMethod'] );
+		$this->assertSame( 'jpg', $payload['labelSettings']['outputType'] );
+
+		// Sender is the consumer returning the item, with contact for track & trace.
+		$this->assertSame( 'NL', $payload['sender']['address']['countryIso'] );
+		$this->assertSame( '9', $payload['sender']['address']['houseNumber'] );
+		$this->assertSame( 'buyer@example.com', $payload['sender']['contact']['email'] );
+
+		// Receiver is the merchant return address.
+		$this->assertSame( 'My Shop', $payload['receiver']['address']['companyName'] );
+		$this->assertSame( '42', $payload['receiver']['address']['houseNumber'] );
+
+		$this->assertSame( '3SDEVCRET123', $payload['items'][0]['barcode'] );
+		$this->assertSame( 'ORDER-1001', $payload['items'][0]['customerReferences']['shipmentReference'] );
+		$this->assertSame( 1500, $payload['items'][0]['dimensions']['weight'], 'Weight must be sent in grams.' );
+	}
+
+	/**
+	 * @testdox build() defaults the print method to retailPrint for an unknown value.
+	 */
+	public function test_print_method_defaults_to_retail(): void {
+		$fields                 = $this->return_fields();
+		$fields['print_method'] = 'nonsense';
+
+		$this->assertSame( LabelPrintMethod::Retail->value, $this->payload( $fields )['labelSettings']['printMethod'] );
+	}
+
+	/**
+	 * @testdox build() omits the returnOptions block, so no returnPeriod or service flags are sent.
+	 */
+	public function test_return_options_omitted(): void {
+		$payload = $this->payload( $this->return_fields() );
+
+		$this->assertArrayNotHasKey( 'returnOptions', $payload, 'returnPeriod is omitted (V4 default 35 days) and there are no return services.' );
+		$json = (string) json_encode( $payload );
+		$this->assertStringNotContainsStringIgnoringCase( 'returnPeriod', $json );
+	}
+
+	/**
+	 * @testdox build() never injects the merchant customer number/code (the SDK client adds them).
+	 */
+	public function test_receiver_omits_customer_credentials(): void {
+		$payload = $this->payload( $this->return_fields() );
+
+		$this->assertArrayNotHasKey( 'customerNumber', $payload['receiver'] );
+		$this->assertArrayNotHasKey( 'customerCode', $payload['receiver'] );
+	}
+
+	/**
+	 * @testdox build() encodes a reply-number (Antwoordnummer) receiver as a valid address.
+	 */
+	public function test_reply_number_addressing_is_valid(): void {
+		$address = $this->payload( $this->reply_number_fields() )['receiver']['address'];
+
+		$this->assertSame( 'Antwoordnummer', $address['street'] );
+		$this->assertSame( '12345', $address['houseNumber'] );
+		$this->assertSame( '1000AA', $address['postalCode'] );
+		$this->assertSame( 'Amsterdam', $address['city'] );
+	}
+
+	/**
+	 * @testdox build() encodes a return-to-home receiver as a valid address.
+	 */
+	public function test_return_to_home_addressing_is_valid(): void {
+		$address = $this->payload( $this->return_fields() )['receiver']['address'];
+
+		$this->assertSame( 'Siriusdreef', $address['street'] );
+		$this->assertSame( '42', $address['houseNumber'] );
+		$this->assertSame( '2132WT', $address['postalCode'] );
+		$this->assertSame( 'Hoofddorp', $address['city'] );
+	}
+
+	/**
+	 * @testdox build() omits the item barcode so the endpoint auto-issues one when none is supplied.
+	 */
+	public function test_empty_barcode_is_omitted(): void {
+		$fields            = $this->return_fields();
+		$fields['barcode'] = '';
+
+		$this->assertArrayNotHasKey( 'barcode', $this->payload( $fields )['items'][0], 'An empty barcode must be dropped, not sent blank.' );
+	}
+
+	/**
+	 * @testdox build() clamps a zero or missing weight to a minimum of one gram.
+	 */
+	public function test_weight_is_clamped_to_minimum(): void {
+		$fields              = $this->return_fields();
+		$fields['weight_gr'] = 0;
+
+		$this->assertSame( 1, $this->payload( $fields )['items'][0]['dimensions']['weight'] );
+	}
+
+	/**
+	 * @testdox build() falls back to PDF for an unknown output type.
+	 */
+	public function test_unknown_output_type_falls_back_to_pdf(): void {
+		$fields          = $this->return_fields();
+		$fields['label'] = array( 'output_type' => 'bmp' );
+
+		$this->assertSame( 'pdf', $this->payload( $fields )['labelSettings']['outputType'] );
+	}
+}

--- a/tests/php/unit/Rest_API/V4/Returns/Response_MapperTest.php
+++ b/tests/php/unit/Rest_API/V4/Returns/Response_MapperTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for Rest_API\V4\Returns\Response_Mapper.
+ *
+ * @package PostNLWooCommerce\Tests\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Tests\Rest_API\V4\Returns;
+
+use Brain\Monkey\Functions;
+use Postnl\Sdk\Client\ResponseMeta;
+use Postnl\Sdk\Enums\Payload\LabelOutputType;
+use Postnl\Sdk\ResponseData\V4\Label;
+use Postnl\Sdk\ResponseData\V4\LabelsCollection;
+use Postnl\Sdk\ResponseData\V4\ReturnShippingItem;
+use Postnl\Sdk\ResponseData\V4\ReturnShippingItemsCollection;
+use Postnl\Sdk\ResponseData\V4\WarningsCollection;
+use Postnl\Sdk\Service\ReturnShipment\V4\Response\GenerateReturnResponseInterface;
+use PostNLWooCommerce\Rest_API\V4\Returns\Response_Mapper;
+use PostNLWooCommerce\Tests\UnitTestCase;
+
+/**
+ * @covers \PostNLWooCommerce\Rest_API\V4\Returns\Response_Mapper
+ */
+class Response_MapperTest extends UnitTestCase {
+
+	/**
+	 * Wrap return items in a stub return/generate response exposing items().
+	 *
+	 * @param ReturnShippingItem ...$items Items to expose.
+	 * @return GenerateReturnResponseInterface
+	 */
+	private function response( ReturnShippingItem ...$items ): GenerateReturnResponseInterface {
+		$collection = new ReturnShippingItemsCollection( $items );
+
+		return new class( $collection ) implements GenerateReturnResponseInterface {
+			public function __construct( private ReturnShippingItemsCollection $items ) {}
+
+			public function items(): ReturnShippingItemsCollection {
+				return $this->items;
+			}
+
+			public function meta(): ResponseMeta {
+				throw new \LogicException( 'meta() is not exercised by these tests.' );
+			}
+
+			public function warnings(): WarningsCollection {
+				throw new \LogicException( 'warnings() is not exercised by these tests.' );
+			}
+		};
+	}
+
+	/**
+	 * @testdox first_return_item() returns the single return item from the response.
+	 */
+	public function test_first_return_item_returns_item(): void {
+		$item = new ReturnShippingItem( barcode: '3SDEVCRET1' );
+
+		$this->assertSame( $item, Response_Mapper::first_return_item( $this->response( $item ) ) );
+	}
+
+	/**
+	 * @testdox first_return_item() returns null when the response carries no return item.
+	 */
+	public function test_first_return_item_returns_null_when_empty(): void {
+		$this->assertNull( Response_Mapper::first_return_item( $this->response() ) );
+	}
+
+	/**
+	 * @testdox get_barcode() prefers the item barcode.
+	 */
+	public function test_get_barcode_prefers_item_barcode(): void {
+		$item = new ReturnShippingItem( barcode: '3SDEVCRET9', returnBarcode: '3SRETURN9' );
+
+		$this->assertSame( '3SDEVCRET9', Response_Mapper::get_barcode( $item, 'fallback' ) );
+	}
+
+	/**
+	 * @testdox get_barcode() falls back to the returnBarcode when the item barcode is absent.
+	 */
+	public function test_get_barcode_falls_back_to_return_barcode(): void {
+		$item = new ReturnShippingItem( barcode: null, returnBarcode: '3SRETURN9' );
+
+		$this->assertSame( '3SRETURN9', Response_Mapper::get_barcode( $item, 'fallback' ) );
+	}
+
+	/**
+	 * @testdox get_barcode() uses the supplied fallback when the response omits both barcodes.
+	 */
+	public function test_get_barcode_uses_fallback(): void {
+		$item = new ReturnShippingItem( barcode: null, returnBarcode: null );
+
+		$this->assertSame( 'fallback-barcode', Response_Mapper::get_barcode( $item, 'fallback-barcode' ) );
+	}
+
+	/**
+	 * @testdox get_partner_barcode()/get_partner_id() capture the international partner refs.
+	 */
+	public function test_partner_refs_captured(): void {
+		$item = new ReturnShippingItem( barcode: '3SDEVCRET1', partnerId: 'DHL', partnerBarcode: 'CD123456785NL' );
+
+		$this->assertSame( 'CD123456785NL', Response_Mapper::get_partner_barcode( $item ) );
+		$this->assertSame( 'DHL', Response_Mapper::get_partner_id( $item ) );
+	}
+
+	/**
+	 * @testdox get_labels() returns only non-empty labels.
+	 */
+	public function test_get_labels_filters_empty(): void {
+		$full  = new Label( label: base64_encode( 'PDF-BYTES' ), outputType: LabelOutputType::PDF, labelType: 'Return Label' );
+		$empty = new Label( label: null );
+		$item  = new ReturnShippingItem( labels: new LabelsCollection( array( $full, $empty ) ) );
+
+		$labels = Response_Mapper::get_labels( $item );
+
+		$this->assertCount( 1, $labels );
+		$this->assertSame( $full, $labels[0] );
+	}
+
+	/**
+	 * @testdox decode_content() base64-decodes the label document bytes.
+	 */
+	public function test_decode_content_decodes_base64(): void {
+		$label = new Label( label: base64_encode( 'PDF-BYTES' ), outputType: LabelOutputType::PDF );
+
+		$this->assertSame( 'PDF-BYTES', Response_Mapper::decode_content( $label ) );
+	}
+
+	/**
+	 * @testdox to_label_record() builds a return-label record in the legacy meta shape tagged as V4.
+	 */
+	public function test_to_label_record_shape(): void {
+		Functions\when( 'current_time' )->justReturn( 1700000000 );
+
+		$record = Response_Mapper::to_label_record( '3SDEVCRET1', '/uploads/postnl/return-label.pdf' );
+
+		$this->assertSame(
+			array(
+				'type'        => 'return-label',
+				'barcode'     => '3SDEVCRET1',
+				'created_at'  => 1700000000,
+				'filepath'    => '/uploads/postnl/return-label.pdf',
+				'api_version' => 'v4',
+			),
+			$record
+		);
+	}
+}

--- a/tests/php/unit/Rest_API/V4/Returns/Response_MapperTest.php
+++ b/tests/php/unit/Rest_API/V4/Returns/Response_MapperTest.php
@@ -69,6 +69,19 @@ class Response_MapperTest extends UnitTestCase {
 	}
 
 	/**
+	 * @testdox first_return_item() returns the first item, not the last.
+	 *
+	 * Every other test builds a response holding exactly one item, where first and
+	 * last are the same object, so reading the wrong end could not be detected.
+	 */
+	public function test_first_return_item_returns_the_first_of_several(): void {
+		$first  = new ReturnShippingItem( barcode: '3SDEVCRET1' );
+		$second = new ReturnShippingItem( barcode: '3SDEVCRET2' );
+
+		$this->assertSame( $first, Response_Mapper::first_return_item( $this->response( $first, $second ) ) );
+	}
+
+	/**
 	 * @testdox get_barcode() prefers the item barcode.
 	 */
 	public function test_get_barcode_prefers_item_barcode(): void {
@@ -96,16 +109,6 @@ class Response_MapperTest extends UnitTestCase {
 	}
 
 	/**
-	 * @testdox get_partner_barcode()/get_partner_id() capture the international partner refs.
-	 */
-	public function test_partner_refs_captured(): void {
-		$item = new ReturnShippingItem( barcode: '3SDEVCRET1', partnerId: 'DHL', partnerBarcode: 'CD123456785NL' );
-
-		$this->assertSame( 'CD123456785NL', Response_Mapper::get_partner_barcode( $item ) );
-		$this->assertSame( 'DHL', Response_Mapper::get_partner_id( $item ) );
-	}
-
-	/**
 	 * @testdox get_labels() returns only non-empty labels.
 	 */
 	public function test_get_labels_filters_empty(): void {
@@ -126,6 +129,21 @@ class Response_MapperTest extends UnitTestCase {
 		$label = new Label( label: base64_encode( 'PDF-BYTES' ), outputType: LabelOutputType::PDF );
 
 		$this->assertSame( 'PDF-BYTES', Response_Mapper::decode_content( $label ) );
+	}
+
+	/**
+	 * @testdox decode_content() returns an empty string for content that is not valid base64.
+	 *
+	 * The decode runs in strict mode so a corrupt payload is rejected outright.
+	 * Without that, PHP skips the invalid characters and returns garbage, which
+	 * Service::store_labels() would then write to disk as a broken label file
+	 * instead of skipping it. Both existing fixtures are valid base64, so dropping
+	 * the strict flag changed nothing that any test could see.
+	 */
+	public function test_decode_content_rejects_invalid_base64(): void {
+		$label = new Label( label: 'not!!valid!!base64', outputType: LabelOutputType::PDF );
+
+		$this->assertSame( '', Response_Mapper::decode_content( $label ) );
 	}
 
 	/**

--- a/tests/php/unit/Rest_API/V4/Returns/ServiceTest.php
+++ b/tests/php/unit/Rest_API/V4/Returns/ServiceTest.php
@@ -1,0 +1,595 @@
+<?php
+/**
+ * Unit tests for Rest_API\V4\Returns\Service.
+ *
+ * @package PostNLWooCommerce\Tests\Rest_API\V4\Returns
+ */
+
+declare( strict_types = 1 );
+
+namespace PostNLWooCommerce\Tests\Rest_API\V4\Returns;
+
+use Brain\Monkey\Functions;
+use GuzzleHttp\Psr7\Response;
+use Postnl\Sdk\Client\ClientBuilder;
+use PostNLWooCommerce\Rest_API\Legacy\Return_Label\Item_Info;
+use PostNLWooCommerce\Rest_API\SDK\Client_Factory;
+use PostNLWooCommerce\Rest_API\V4\Returns\Request_Builder;
+use PostNLWooCommerce\Rest_API\V4\Returns\Service;
+use PostNLWooCommerce\Shipping_Method\Settings;
+use PostNLWooCommerce\Tests\UnitTestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+
+/**
+ * @covers \PostNLWooCommerce\Rest_API\V4\Returns\Service
+ */
+class ServiceTest extends UnitTestCase {
+
+	/**
+	 * API key the Service is constructed with in these tests.
+	 */
+	private const V4_KEY = 'v4-returns-secret';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->seed_settings_singleton();
+
+		// Exception_Converter translates its messages; surface them verbatim in failures.
+		Functions\when( '__' )->returnArg( 1 );
+	}
+
+	protected function tearDown(): void {
+		$this->reset_settings_singleton();
+		parent::tearDown();
+	}
+
+	/**
+	 * Replace the Settings singleton Order\Base hands the service with a double
+	 * overriding exactly the getters it reads. Every unstubbed parent method is left
+	 * alone on purpose: reaching one fatals rather than quietly returning stub data.
+	 *
+	 * @return void
+	 */
+	private function seed_settings_singleton(): void {
+		$double = new class() extends Settings {
+			// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Skips the real constructor, which needs WooCommerce.
+			public function __construct() {}
+
+			public function is_sandbox() {
+				return true;
+			}
+		};
+
+		$property = new \ReflectionProperty( Settings::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, $double );
+	}
+
+	/**
+	 * Clear the seeded singleton so it cannot leak into another test file.
+	 *
+	 * @return void
+	 */
+	private function reset_settings_singleton(): void {
+		$property = new \ReflectionProperty( Settings::class, 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Build a service wired to a fake transport, so nothing reaches the network.
+	 *
+	 * @param ClientInterface   $http   Fake HTTP client.
+	 * @param AbstractLogger|null $logger Optional spy logger.
+	 * @return Testable_Returns_Service
+	 */
+	private function service( ClientInterface $http, ?AbstractLogger $logger = null ): Testable_Returns_Service {
+		return new Testable_Returns_Service(
+			new Spy_Returns_Client_Factory( new Returns_Client_Factory_Settings(), $http ),
+			self::V4_KEY,
+			$logger ?? new NullLogger()
+		);
+	}
+
+	/**
+	 * Call a private method on the service.
+	 *
+	 * Reached by reflection rather than by widening the method to protected. These
+	 * helpers have no collaborators, so promoting them would buy nothing and would
+	 * enlarge the class's public shape purely for the tests.
+	 *
+	 * @param Service $service Service under test.
+	 * @param string  $method  Method name.
+	 * @param mixed   ...$args Arguments.
+	 * @return mixed
+	 */
+	private function call_private( Service $service, string $method, ...$args ) {
+		$reflected = new \ReflectionMethod( Service::class, $method );
+		$reflected->setAccessible( true );
+
+		return $reflected->invoke( $service, ...$args );
+	}
+
+	/**
+	 * A parsed return item info for a Dutch customer of a Dutch store.
+	 *
+	 * @param string $customer_country Customer (return sender) country.
+	 * @param string $printer_type     Merchant's combined printer-type string.
+	 * @return Item_Info
+	 */
+	private function item_info( string $customer_country = 'NL', string $printer_type = 'GraphicFile|JPG 600 dpi' ): Item_Info {
+		return new Fake_Return_Item_Info( $customer_country, $printer_type );
+	}
+
+	// ── Eligibility ──────────────────────────────────────────────────────────
+
+	/**
+	 * @testdox A Dutch customer is eligible for the V4 retailPrint return
+	 */
+	public function test_dutch_customer_is_eligible(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$this->assertTrue( $this->call_private( $service, 'is_eligible', $this->item_info( 'NL' ) ) );
+	}
+
+	/**
+	 * @testdox A Belgian customer is not eligible, even though the store is Dutch
+	 *
+	 * The print method follows the country the parcel is handed in from, which is
+	 * the customer's. The SDK states it on LabelPrintMethod: sending from BE allows
+	 * only consumerPrint, and consumerPrint is not implemented. Reading the store
+	 * country instead would always say yes, because the plugin refuses to run unless
+	 * the store is in NL or BE — and Mapping::option_available_list() does offer
+	 * create_return_label for NL to BE, so this case is reachable.
+	 */
+	public function test_belgian_customer_is_not_eligible(): void {
+		$service   = $this->service( new Failing_Returns_Http_Client() );
+		$item_info = $this->item_info( 'BE' );
+
+		// The store stays Dutch, so only the customer's country can decide this.
+		$this->assertSame( 'NL', $item_info->shipper['country'] );
+		$this->assertFalse( $this->call_private( $service, 'is_eligible', $item_info ) );
+	}
+
+	// ── create() guard order ─────────────────────────────────────────────────
+
+	/**
+	 * @testdox create() returns the legacy pipeline result without building Item_Info when the box is unticked
+	 *
+	 * Item_Info extends Shipping\Item_Info, which lists main_barcode as required with
+	 * no default and throws "Barcode is empty!" when it is absent. This post data has
+	 * no main_barcode, so building it before the checkbox check would turn an
+	 * ordinary save into an error about barcodes.
+	 */
+	public function test_create_without_the_checkbox_never_builds_item_info(): void {
+		$http    = new Failing_Returns_Http_Client();
+		$service = $this->service( $http );
+
+		$result = $service->create(
+			array(
+				'saved_data' => array( 'backend' => array( 'create_return_label' => 'no' ) ),
+			)
+		);
+
+		$this->assertSame( array( 'legacy-pipeline' => true ), $result );
+		$this->assertSame( 1, $service->pipeline_calls );
+		$this->assertNull( $http->last_request, 'The SDK must not be called when no return label was requested.' );
+	}
+
+	/**
+	 * @testdox create() falls back to the legacy pipeline when the key is missing entirely
+	 */
+	public function test_create_falls_back_when_the_flag_is_absent(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$this->assertSame( array( 'legacy-pipeline' => true ), $service->create( array( 'saved_data' => array( 'backend' => array() ) ) ) );
+		$this->assertSame( 1, $service->pipeline_calls );
+	}
+
+	// ── Field extraction ─────────────────────────────────────────────────────
+
+	/**
+	 * @testdox extract_fields() carries the return barcode, order number and weight
+	 *
+	 * The three numbers are kept distinct in the fixture so reading the wrong key
+	 * cannot pass by coincidence.
+	 */
+	public function test_extract_fields_carries_the_order_values(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$fields = $this->call_private(
+			$service,
+			'extract_fields',
+			$this->item_info(),
+			array( 'return_barcode' => '3SDEVCRET77' )
+		);
+
+		$this->assertSame( '3SDEVCRET77', $fields['barcode'] );
+		$this->assertSame( 'ORDER-4242', $fields['reference'] );
+		$this->assertSame( 1500, $fields['weight_gr'] );
+		$this->assertSame( 'retailPrint', $fields['print_method'] );
+	}
+
+	/**
+	 * @testdox extract_fields() maps the customer to the sender and the return address to the receiver
+	 *
+	 * A return travels customer to merchant, so the outbound recipient becomes the
+	 * return sender.
+	 */
+	public function test_extract_fields_swaps_the_parties(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$fields = $this->call_private( $service, 'extract_fields', $this->item_info(), array() );
+
+		$this->assertSame( 'Kalverstraat', $fields['sender']['street'] );
+		$this->assertSame( 'buyer@example.com', $fields['sender']['email'] );
+		$this->assertSame( 'Antwoordnummer', $fields['receiver']['street'] );
+		$this->assertSame( '12345', $fields['receiver']['house_number'] );
+	}
+
+	/**
+	 * @testdox extract_fields() carries both halves of the printer setting
+	 *
+	 * The merchant's setting is one combined string holding the format and the dpi.
+	 * Keeping only the format left every return label at the SDK's 200 dpi default,
+	 * silently downgrading a merchant configured for 600.
+	 */
+	public function test_extract_fields_carries_output_type_and_resolution(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$fields = $this->call_private(
+			$service,
+			'extract_fields',
+			$this->item_info( 'NL', 'Zebra|Generic ZPL II 300 dpi' ),
+			array()
+		);
+
+		$this->assertSame( 'zpl', $fields['label']['output_type'] );
+		$this->assertSame( 300, $fields['label']['resolution'] );
+	}
+
+	/**
+	 * @testdox extract_fields() falls back to 200 dpi for a printer setting carrying no dpi
+	 */
+	public function test_extract_fields_defaults_the_resolution_for_pdf(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+
+		$fields = $this->call_private( $service, 'extract_fields', $this->item_info( 'NL', 'GraphicFile|PDF' ), array() );
+
+		$this->assertSame( 'pdf', $fields['label']['output_type'] );
+		$this->assertSame( 200, $fields['label']['resolution'] );
+	}
+
+	// ── Client construction ──────────────────────────────────────────────────
+
+	/**
+	 * @testdox The SDK client authenticates with the injected key, not one re-read from settings
+	 *
+	 * The key is resolved and validated by Service_Factory before it decides V4 may
+	 * run at all. Re-deriving it inside the service duplicated that decision behind a
+	 * method_exists() guard that fell back to an empty key.
+	 */
+	public function test_client_authenticates_with_the_injected_key(): void {
+		$http    = new Failing_Returns_Http_Client();
+		$service = $this->service( $http );
+		$fields  = $this->call_private( $service, 'extract_fields', $this->item_info(), array() );
+
+		try {
+			$service->expose_generate_return( Request_Builder::build( $fields ), $fields );
+		} catch ( \Exception $error ) {
+			unset( $error );
+		}
+
+		$this->assertNotNull( $http->last_request, 'The request must reach the transport.' );
+		$this->assertSame( self::V4_KEY, $http->last_request->getHeaderLine( 'apiKey' ) );
+	}
+
+	// ── Error handling and logging ───────────────────────────────────────────
+
+	/**
+	 * @testdox An SDK failure surfaces as the converted, merchant-facing error
+	 */
+	public function test_sdk_failure_surfaces_as_the_converted_error(): void {
+		$service = $this->service( new Failing_Returns_Http_Client() );
+		$fields  = $this->call_private( $service, 'extract_fields', $this->item_info(), array() );
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Invalid PostNL API credentials. (traceId: trace-ret)' );
+
+		$service->expose_generate_return( Request_Builder::build( $fields ), $fields );
+	}
+
+	/**
+	 * @testdox A failed return call is logged at error level with the original SDK cause
+	 *
+	 * Exception_Converter replaces the SDK message with a merchant-safe one and keeps
+	 * the original only as the previous exception, which nothing else reads. One of
+	 * its variants tells the merchant to check these very logs, so without this line
+	 * the message would point at a file where nothing had been written.
+	 */
+	public function test_failed_return_call_is_logged_with_the_original_cause(): void {
+		$logger  = new Spy_Returns_Logger();
+		$service = $this->service( new Failing_Returns_Http_Client(), $logger );
+		$fields  = $this->call_private( $service, 'extract_fields', $this->item_info(), array() );
+
+		try {
+			$service->expose_generate_return( Request_Builder::build( $fields ), $fields );
+		} catch ( \Exception $error ) {
+			unset( $error );
+		}
+
+		$this->assertCount( 1, $logger->records, 'Exactly one entry must be written for a failed call.' );
+		$this->assertSame( 'error', $logger->records[0]['level'] );
+		$this->assertStringContainsString( 'ORDER-4242', $logger->records[0]['message'], 'The order number makes the entry traceable.' );
+		$this->assertStringContainsString( 'apiKey header missing or invalid', $logger->records[0]['message'], 'The original SDK detail must survive.' );
+	}
+
+	/**
+	 * @testdox A successful return call writes nothing to the log
+	 */
+	public function test_successful_return_call_is_not_logged(): void {
+		$logger  = new Spy_Returns_Logger();
+		$service = $this->service( new Succeeding_Returns_Http_Client(), $logger );
+		$fields  = $this->call_private( $service, 'extract_fields', $this->item_info(), array() );
+
+		$service->expose_generate_return( Request_Builder::build( $fields ), $fields );
+
+		$this->assertSame( array(), $logger->records );
+	}
+}
+
+/**
+ * Service exposing the protected transport method and standing in for the legacy
+ * pipeline, which needs a WooCommerce order.
+ */
+class Testable_Returns_Service extends Service {
+
+	/**
+	 * How many times the legacy fallback ran.
+	 *
+	 * @var int
+	 */
+	public int $pipeline_calls = 0;
+
+	/**
+	 * Record the fallback instead of running the WooCommerce-bound pipeline.
+	 *
+	 * @param array $post_data Order post data.
+	 * @return array
+	 */
+	protected function maybe_create_return_label_pipeline( $post_data ) {
+		unset( $post_data );
+		++$this->pipeline_calls;
+
+		return array( 'legacy-pipeline' => true );
+	}
+
+	/**
+	 * Reach the protected transport method.
+	 *
+	 * @param \Postnl\Sdk\Service\ReturnShipment\V4\Request\ReturnShipmentRequest $request Built request.
+	 * @param array                                                              $fields  Flattened fields.
+	 * @return \Postnl\Sdk\Service\ReturnShipment\V4\Response\GenerateReturnResponseInterface
+	 */
+	public function expose_generate_return( $request, array $fields ) {
+		return $this->generate_return( $request, $fields );
+	}
+}
+
+/**
+ * Return item info with the parsed properties set directly, skipping the
+ * WooCommerce-bound parent constructor.
+ */
+class Fake_Return_Item_Info extends Item_Info {
+
+	/**
+	 * @param string $customer_country Customer (return sender) country.
+	 * @param string $printer_type     Merchant's combined printer-type string.
+	 */
+	// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Deliberately skips the WooCommerce-bound parent constructor.
+	public function __construct( string $customer_country = 'NL', string $printer_type = 'GraphicFile|JPG 600 dpi' ) {
+		// The store is always Dutch here, so only the customer's country can decide
+		// eligibility. The plugin refuses to run on a store outside NL or BE.
+		$this->shipper  = array( 'country' => 'NL' );
+		$this->receiver = array(
+			'company'      => '',
+			'first_name'   => 'Jan',
+			'last_name'    => 'Jansen',
+			'address_1'    => 'Kalverstraat',
+			'house_number' => '9',
+			'address_2'    => 'A',
+			'postcode'     => '1234AB',
+			'city'         => 'Amsterdam',
+			'country'      => $customer_country,
+		);
+		$this->customer = array(
+			'return_company'     => 'My Shop',
+			'return_address_1'   => 'Antwoordnummer',
+			'return_address_2'   => '12345',
+			'return_address_zip' => '1000AA',
+			'return_address_city' => 'Amsterdam',
+		);
+		$this->shipment = array(
+			'email'        => 'buyer@example.com',
+			'phone'        => '0612345678',
+			'order_number' => 'ORDER-4242',
+			'total_weight' => 1500,
+			'printer_type' => $printer_type,
+		);
+	}
+}
+
+/**
+ * Minimal settings stand-in for Client_Factory, which only reads the customer
+ * credentials off the object it is handed.
+ */
+class Returns_Client_Factory_Settings {
+
+	/**
+	 * @return string
+	 */
+	public function get_customer_num() {
+		return '11223344';
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_customer_code() {
+		return 'DEVC';
+	}
+}
+
+/**
+ * Client_Factory whose SDK builder is wired to a fake HTTP client so no network
+ * call is made, while the production client configuration stays intact.
+ */
+class Spy_Returns_Client_Factory extends Client_Factory {
+
+	/**
+	 * Fake HTTP client injected into every built SDK client.
+	 *
+	 * @var ClientInterface
+	 */
+	private ClientInterface $http_client;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param object          $settings    Settings stub.
+	 * @param ClientInterface $http_client Fake HTTP client.
+	 */
+	public function __construct( object $settings, ClientInterface $http_client ) {
+		parent::__construct( $settings );
+		$this->http_client = $http_client;
+	}
+
+	/**
+	 * Attach the fake HTTP client to the configured builder.
+	 *
+	 * @param string $v4_key          V4 API key.
+	 * @param bool   $is_sandbox      Sandbox flag.
+	 * @param string $customer_number PostNL customer number.
+	 * @param string $customer_code   PostNL customer code.
+	 * @return ClientBuilder
+	 */
+	protected function make_builder( string $v4_key, bool $is_sandbox, string $customer_number, string $customer_code ): ClientBuilder {
+		return parent::make_builder( $v4_key, $is_sandbox, $customer_number, $customer_code )
+			->withHttpClient( $this->http_client );
+	}
+}
+
+/**
+ * PSR-18 client that always answers with a PostNL problem+json error.
+ *
+ * 401 is chosen because the SDK's retry policy treats it as permanent, so the
+ * failure surfaces on the first attempt with no backoff sleeps in the test.
+ */
+class Failing_Returns_Http_Client implements ClientInterface {
+
+	/**
+	 * The most recent outgoing request, captured for header assertions.
+	 *
+	 * @var RequestInterface|null
+	 */
+	public ?RequestInterface $last_request = null;
+
+	/**
+	 * Return the canned error response.
+	 *
+	 * @param RequestInterface $request Outgoing request.
+	 * @return ResponseInterface
+	 */
+	public function sendRequest( RequestInterface $request ): ResponseInterface {
+		$this->last_request = $request;
+
+		return new Response(
+			401,
+			array( 'Content-Type' => 'application/problem+json' ),
+			(string) json_encode(
+				array(
+					'title'   => 'Unauthorized',
+					'detail'  => 'apiKey header missing or invalid',
+					'traceId' => 'trace-ret',
+				)
+			)
+		);
+	}
+}
+
+/**
+ * PSR-18 client answering with a minimal successful return/generate body.
+ */
+class Succeeding_Returns_Http_Client implements ClientInterface {
+
+	/**
+	 * The most recent outgoing request.
+	 *
+	 * @var RequestInterface|null
+	 */
+	public ?RequestInterface $last_request = null;
+
+	/**
+	 * Return the canned success response.
+	 *
+	 * @param RequestInterface $request Outgoing request.
+	 * @return ResponseInterface
+	 */
+	public function sendRequest( RequestInterface $request ): ResponseInterface {
+		$this->last_request = $request;
+
+		return new Response(
+			200,
+			array( 'Content-Type' => 'application/json' ),
+			(string) json_encode(
+				array(
+					'items' => array(
+						array(
+							'barcode' => '3SDEVCRET77',
+							'labels'  => array(
+								array(
+									'label'      => base64_encode( 'JPG-BYTES' ),
+									'outputType' => 'jpg',
+									'labelType'  => 'Return Label',
+								),
+							),
+						),
+					),
+				)
+			)
+		);
+	}
+}
+
+/**
+ * PSR-3 logger that records every write for assertion.
+ */
+class Spy_Returns_Logger extends AbstractLogger {
+
+	/**
+	 * Recorded log calls, each as array{level: mixed, message: string, context: array}.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $records = array();
+
+	/**
+	 * Record the call.
+	 *
+	 * @param mixed              $level   PSR-3 level.
+	 * @param string|\Stringable $message Log message.
+	 * @param array              $context Context values.
+	 * @return void
+	 */
+	public function log( $level, string|\Stringable $message, array $context = array() ): void {
+		$this->records[] = array(
+			'level'   => $level,
+			'message' => (string) $message,
+			'context' => $context,
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

<!-- Admin-side return-label generation behind the default-off V4 return flow gate; the checkout-flow boxes are not applicable. -->

### Changes proposed in this Pull Request:

ClickUp: [22. V4 Returns service (return/generate)](https://app.clickup.com/t/868jqaqhh)

Adds a unified V4 Returns service backing `POST /shipment/delivery/v4/return/generate`. PostNL confirmed (2026-05-21) the three legacy return mechanisms collapse onto this one endpoint, differentiated by `printMethod` and receiver address. Stacked on `postnl-v4-shipping-label-domestic-parcel` (task 18) because it shares the SDK plumbing (`Exception_Converter`) introduced there.

- **`V4\Returns\Request_Builder`** (pure) — builds the `ReturnShipmentRequest`: `sender` = the consumer returning the item (with contact), `receiver` = the merchant return address, `labelSettings.printMethod` = `retailPrint`, `shipmentType` = `parcel`, one item (barcode auto-issued when none supplied). **No `returnOptions` block** — `returnPeriod` is omitted (V4 default is 35 days; PostNL do not want it differentiated) and there are no additional return services. Merchant `customerNumber`/`customerCode` are injected by the SDK client, so they're absent here.
- **`V4\Returns\Response_Mapper`** (pure) — captures the issued barcode (item → `returnBarcode` → fallback), the label document(s), and the international partner refs.
- **`V4\Returns\Service`** — implements `Return_Label_Service_Interface`. `create()` builds the request from the order + return-address settings, calls `returns()->generateReturn()`, and stores the result via the shared `Order\Base` helpers as `_postnl_order_metadata['labels']['return-label']`. Only the NL `retailPrint` flow is handled; a non-NL origin (consumerPrint is a BE follow-on) falls back to the legacy pipeline. `activate()` is unchanged — it still delegates to the legacy V1 `/parcels/v1/shipment/activatereturn` endpoint, which is not part of this migration.

**Reply-number vs return-to-home is encoded in the receiver address** (resolves open question §14): the freepost/Antwoordnummer receiver (Street `Antwoordnummer`, house number = reply number, freepost zip/city) vs the merchant home address, gated by `Settings::is_return_to_home_enabled()` — both produce valid requests. Both gates (validated New API Key + the return flow flag) default off, so merging changes nothing for merchants.

### How to test the changes in this Pull Request:

1. Run the PHP unit suite: `vendor/bin/phpunit -c phpunit-unit.xml.dist` — all pass (18 new Returns tests).
2. `composer check-php` — no violations on the new files.
3. Review the request DTO tests: `retailPrint` + parcel, `returnOptions`/`returnPeriod` omitted, no service flags, and both reply-number and return-to-home receiver addressing serialize to valid requests.
4. With a validated New API Key and the return flow flag on a NL store, generate a return label for an order and confirm the request hits `return/generate` with `printMethod: retailPrint` and the correct receiver address for the configured reply-number vs home setting; the returned barcode + label are stored as `labels['return-label']`.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Internal (no merchant-visible change): add a V4 SDK Returns service generating NL retailPrint return labels via `return/generate`, behind the default-off return flow flag.
