### PR TITLE
23. V4 Letterbox — domestic NL 24h letterbox on the SDK label flow

### DIFF
--- a/src/Rest_API/V4/Label/Eligibility.php
+++ b/src/Rest_API/V4/Label/Eligibility.php
@@ -17,10 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Pure decision logic for whether an order is a parcel the V4 label service
- * handles — a domestic NL parcel or an EU/ROW international parcel from NL/BE.
- * Kept free of WooCommerce and Order\Base so the gate — the highest-risk part
- * of the flow — can be asserted in isolation.
+ * Pure decision logic for whether an order is a shipment the V4 label service
+ * handles — a domestic NL parcel, a domestic NL letterbox (mailbox parcel), or
+ * an EU/ROW international parcel from NL/BE. Kept free of WooCommerce and
+ * Order\Base so the gate — the highest-risk part of the flow — can be asserted
+ * in isolation.
  *
  * @since   6.0.0
  * @package PostNLWooCommerce\Rest_API\V4\Label
@@ -55,8 +56,9 @@ class Eligibility {
 	}
 
 	/**
-	 * Decide whether the collected signals describe a parcel the V4 service handles
-	 * — a domestic NL or EU/ROW international parcel, single- or multi-collo.
+	 * Decide whether the collected signals describe a shipment the V4 service
+	 * handles — a domestic NL or EU/ROW international parcel (single- or
+	 * multi-collo), or a domestic NL letterbox (mailbox parcel 2928).
 	 *
 	 * @param array $signals {
 	 *     Signal set assembled by Service::gather_signals().
@@ -108,11 +110,23 @@ class Eligibility {
 		// equivalent, its services array is the full V4 representation of every
 		// selected option, so no separate product-option gate is needed. Only a
 		// pickup DeliveryLocation is excluded here — that variant lands separately.
-		$mapped = $signals['mapped'] ?? array();
+		$mapped        = $signals['mapped'] ?? array();
+		$shipment_type = (string) ( $mapped['shipmentType'] ?? '' );
 
-		return ! empty( $mapped['has_v4_equivalent'] )
-			&& 'parcel' === ( $mapped['shipmentType'] ?? '' )
-			&& empty( $mapped['deliveryLocation'] );
+		if ( empty( $mapped['has_v4_equivalent'] ) || ! empty( $mapped['deliveryLocation'] ) ) {
+			return false;
+		}
+
+		// Letterbox (mailbox parcel 2928) is a domestic-NL-only variant. The 48h
+		// variant (2948) never reaches here: it collapses onto the same 'letterbox'
+		// option key but keeps product code 2948, so the mapper's product-code
+		// mismatch guard drops it to has_v4_equivalent = false above. A parcel may
+		// be domestic or EU/ROW international.
+		if ( 'letterbox' === $shipment_type ) {
+			return $is_domestic;
+		}
+
+		return 'parcel' === $shipment_type;
 	}
 
 	/**

--- a/src/Rest_API/V4/Label/Service.php
+++ b/src/Rest_API/V4/Label/Service.php
@@ -40,9 +40,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * confirmation, stated-address-only, return-when-not-home and their
  * combinations — for domestic NL shipments, plus EU/ROW international parcels
  * (4907/4909) carrying an InternationalShipmentData bundle and customs
- * declaration. Everything else — pickup (DeliveryLocation), packet/mailbox
- * international products, returns, delivery-day/evening selection — falls back to
- * the untouched legacy pipeline until those flows are migrated. Because both
+ * declaration. The domestic NL 24h letterbox (mailbox parcel 2928) also falls
+ * out here as a ShipmentType::LetterBox variant. Everything else — pickup
+ * (DeliveryLocation), the 48h letterbox (2948), packet/mailbox international
+ * products, returns, delivery-day/evening selection — falls back to the
+ * untouched legacy pipeline until those flows are migrated. Because both
  * gates (a validated V4 key and the per-flow flag) default off, merging this
  * changes nothing for merchants.
  *

--- a/tests/php/unit/Rest_API/V4/Label/EligibilityTest.php
+++ b/tests/php/unit/Rest_API/V4/Label/EligibilityTest.php
@@ -123,6 +123,77 @@ class EligibilityTest extends UnitTestCase {
 	}
 
 	/**
+	 * @testdox is_eligible() accepts a domestic NL letterbox (mailbox parcel 2928).
+	 */
+	public function test_letterbox_is_eligible(): void {
+		$signals = $this->signals(
+			array(
+				'mapped' => array(
+					'has_v4_equivalent' => true,
+					'shipmentType'      => 'letterbox',
+					'services'          => array(),
+					'deliveryLocation'  => array(),
+				),
+			)
+		);
+
+		$this->assertTrue( Eligibility::is_eligible( $signals ), 'A domestic NL letterbox should route to V4.' );
+	}
+
+	/**
+	 * @testdox is_eligible() rejects a letterbox shipment type for a non-domestic destination.
+	 *
+	 * Letterbox is a NL-only mailbox parcel; the mapper never yields it for an
+	 * international destination, and the gate must reject it even if one is forced.
+	 */
+	public function test_international_letterbox_is_ineligible(): void {
+		$signals = $this->signals(
+			array(
+				'destination' => 'EU',
+				'mapped'      => array(
+					'has_v4_equivalent' => true,
+					'shipmentType'      => 'letterbox',
+					'services'          => array(),
+					'deliveryLocation'  => array(),
+				),
+			)
+		);
+
+		$this->assertFalse( Eligibility::is_eligible( $signals ), 'An international letterbox must fall back to legacy.' );
+	}
+
+	/**
+	 * @testdox resolve_mapped() maps a 24h letterbox (2928) to the letterbox shipment type, eligible end-to-end.
+	 */
+	public function test_resolve_mapped_letterbox_is_eligible(): void {
+		$mapped = Eligibility::resolve_mapped( 'NL', 'NL', false, array( 'letterbox' => 'yes' ), '2928' );
+
+		$this->assertTrue( $mapped['has_v4_equivalent'] );
+		$this->assertSame( 'letterbox', $mapped['shipmentType'] );
+		$this->assertTrue(
+			Eligibility::is_eligible( $this->signals( array( 'mapped' => $mapped ) ) ),
+			'A 24h letterbox should route to V4.'
+		);
+	}
+
+	/**
+	 * @testdox resolve_mapped() keeps the 48h letterbox (2948) off V4 via the product-code mismatch guard.
+	 *
+	 * The 24h and 48h letterbox share the collapsed 'letterbox' option key, so the
+	 * matrix row resolves to product 2928; a 2948 order fails the mismatch guard
+	 * and must fall back to legacy rather than ship as a 24h letterbox.
+	 */
+	public function test_resolve_mapped_letterbox_48_falls_back(): void {
+		$mapped = Eligibility::resolve_mapped( 'NL', 'NL', false, array( 'letterbox' => 'yes' ), '2948' );
+
+		$this->assertFalse( $mapped['has_v4_equivalent'], 'A 48h letterbox (2948) must not resolve to a V4 equivalent.' );
+		$this->assertFalse(
+			Eligibility::is_eligible( $this->signals( array( 'mapped' => $mapped ) ) ),
+			'A 48h letterbox must fall back to the legacy path.'
+		);
+	}
+
+	/**
 	 * @testdox is_eligible() rejects orders outside the happy path.
 	 * @dataProvider ineligible_provider
 	 *
@@ -154,7 +225,7 @@ class EligibilityTest extends UnitTestCase {
 			// Leaving the other mapped keys out would let the shipmentType check reject
 			// this row first, so has_v4_equivalent itself would never be exercised.
 			'no v4 equivalent'           => array( array( 'mapped' => array( 'has_v4_equivalent' => false, 'shipmentType' => 'parcel', 'services' => array(), 'deliveryLocation' => array() ) ), 'no V4 equivalent' ),
-			'non-parcel shipment type'   => array( array( 'mapped' => array( 'has_v4_equivalent' => true, 'shipmentType' => 'letterbox', 'services' => array() ) ), 'a letterbox shipment type' ),
+			'unsupported shipment type'  => array( array( 'mapped' => array( 'has_v4_equivalent' => true, 'shipmentType' => 'pallet', 'services' => array() ) ), 'an unsupported shipment type' ),
 			'mapped with pickup location' => array( array( 'mapped' => array( 'has_v4_equivalent' => true, 'shipmentType' => 'parcel', 'services' => array(), 'deliveryLocation' => array( 'pickupLocationId' => 'x' ) ) ), 'a pickup delivery location' ),
 		);
 	}

--- a/tests/php/unit/Rest_API/V4/Label/Request_BuilderTest.php
+++ b/tests/php/unit/Rest_API/V4/Label/Request_BuilderTest.php
@@ -312,6 +312,18 @@ class Request_BuilderTest extends UnitTestCase {
 	}
 
 	/**
+	 * @testdox build() maps the letterbox shipment type to ShipmentType::LetterBox.
+	 */
+	public function test_letterbox_shipment_type(): void {
+		$fields                  = $this->domestic_fields();
+		$fields['shipment_type'] = 'letterbox';
+
+		$payload = $this->payload( $fields );
+
+		$this->assertSame( ShipmentType::LetterBox->value, $payload['shipmentType'] );
+	}
+
+	/**
 	 * @testdox build() omits the Services block for a plain parcel with no service flags.
 	 */
 	public function test_services_omitted_when_empty(): void {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

<!-- Checkout boxes left unchecked: this PR only touches backend label generation (the V4 label eligibility gate), not the cart/checkout. Placing a real V4 letterbox order needs a validated New API Key + the flag on against the PostNL sandbox — see the manual note below. -->

### Changes proposed in this Pull Request:

Task 23 — bring the **domestic NL 24h Letterbox** (mailbox parcel `2928`) onto the V4 label flow.

As the task predicted, letterbox "falls out of the label service": the V4 `Request_Builder` already maps a `letterbox` shipment type to `ShipmentType::LetterBox`, and `V4_Mapper` row 12 already resolves the collapsed `letterbox` option to `2928` / shipment type `letterbox`. The only thing keeping it on legacy was `V4\Label\Eligibility::is_eligible()`, which accepted `parcel` only.

- `Eligibility::is_eligible()` now also accepts the `letterbox` shipment type, **restricted to domestic NL** (parcels may still be domestic or EU/ROW international; letterbox may not).
- No separate barcode call and no meta-shape change: letterbox already rides `Order\Base::create_label()` → `label_service()` and its label is stored under type `label`, exactly as the legacy path does today (the standalone `maybe_create_letterbox()` entry point is not used by the save flow). Because it shares that entry point, it is gated by the existing `postnl_sdk_enable_label` flow flag.
- The **48h Letterbox (`2948`)** stays on legacy automatically: it collapses onto the same `letterbox` option key but keeps product code `2948`, so the mapper's product-code mismatch guard drops it to `has_v4_equivalent = false`.

Both gates (a validated New API Key **and** `postnl_sdk_enable_label`) default off, so merging changes nothing for merchants.

Closes # . — ClickUp: https://app.clickup.com/t/868jqaqhm

### How to test the changes in this Pull Request:

Automated (runnable now, no Docker/sandbox needed — unit suite is pure PHP):

1. `vendor/bin/phpunit -c phpunit-unit.xml.dist --filter 'EligibilityTest|Request_BuilderTest'` — new cases: 24h letterbox is eligible, 48h (2948) falls back, an international letterbox is rejected, and the builder maps `letterbox` → `ShipmentType::LetterBox`.
2. `vendor/bin/phpunit -c phpunit-unit.xml.dist` — full suite stays green (499 tests).
3. `composer run check-php` — WPCS clean.

The unit tests drive `resolve_mapped()` with the resolved product code directly; the runtime `_postnl_letterbox_type` meta → `get_product_code()` → `2948` linkage that makes a 48h order fall back is covered by the existing integration test `tests/php/integration/LetterboxTypeTest.php`.

Manual (needs a validated New API Key + PostNL sandbox):

1. On a NL store, enter and validate a New API Key, then set `add_filter( 'postnl_sdk_enable_label', '__return_true' );`.
2. Place/prepare a NL order that qualifies for auto-letterbox (all items letterbox-eligible, combined weight ≤ 2 kg) with the letterbox product default set to **24h**.
3. Generate the label from the order meta box. Expect: a letterbox label PDF stored as before, the barcode captured from the response, and `_postnl_order_metadata['labels']` tagged `api_version = v4` — identical shape to V1.
4. Repeat with the default set to **48h** and confirm it still generates via the legacy path (no `api_version = v4` tag).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Enable the PostNL V4 SDK for the domestic NL 24h Letterbox label (behind the default-off label flag); the 48h Letterbox remains on the legacy API.
